### PR TITLE
ECC-981 refactor access logic to check enrolment at a later stage

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/EnrolmentAlreadyExistsController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/EnrolmentAlreadyExistsController.scala
@@ -37,14 +37,14 @@ class EnrolmentAlreadyExistsController @Inject() (
 
   // Note: permitted for user with service enrolment
   def enrolmentAlreadyExists(service: Service): Action[AnyContent] =
-    authAction.ggAuthorisedUserWithServiceAction {
+    authAction.ggAuthorisedUserAction {
       implicit request => _: LoggedInUserWithEnrolments =>
         Future.successful(Ok(registrationExistsView(service)))
     }
 
   // Note: permitted for user with service enrolment
   def enrolmentAlreadyExistsForGroup(service: Service): Action[AnyContent] =
-    authAction.ggAuthorisedUserWithServiceAction {
+    authAction.ggAuthorisedUserAction {
       implicit request => _: LoggedInUserWithEnrolments =>
         Future.successful(Ok(registrationExistsForGroupView(service)))
     }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/auth/AccessController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/auth/AccessController.scala
@@ -39,15 +39,22 @@ trait AccessController {
 
     def isPermittedUserType: Boolean =
       affinityGroup match {
-        case Some(Agent)        => false
-        case Some(Organisation) => credentialRole.fold(false)(cr => cr == User)
-        case _                  => true
+        case Some(Agent) => false
+        case _           => true
+      }
+
+    def isPermittedCredentialRole: Boolean =
+      credentialRole match {
+        case Some(User) => true
+        case _          => false
       }
 
     if (!isPermittedUserType)
       Future.successful(Redirect(routes.YouCannotUseServiceController.page(service)))
     else if (hasEnrolment)
       Future.successful(Redirect(routes.EnrolmentAlreadyExistsController.enrolmentAlreadyExists(service)))
+    else if (!isPermittedCredentialRole)
+      Future.successful(Redirect(routes.YouCannotUseServiceController.page(service)))
     else
       action
   }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/auth/AccessController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/auth/AccessController.scala
@@ -32,7 +32,7 @@ trait AccessController {
     affinityGroup: Option[AffinityGroup],
     credentialRole: Option[CredentialRole],
     enrolments: Set[Enrolment]
-  )(action: Future[Result])(implicit request: Request[AnyContent]): Future[Result] = {
+  )(action: => Future[Result])(implicit request: Request[AnyContent]): Future[Result] = {
 
     def hasEnrolment(implicit request: Request[AnyContent]): Boolean =
       Service.serviceFromRequest.exists(service => enrolments.exists(_.key.equalsIgnoreCase(service.enrolmentKey)))

--- a/test/unit/controllers/ApplicationControllerSpec.scala
+++ b/test/unit/controllers/ApplicationControllerSpec.scala
@@ -20,7 +20,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import play.api.test.Helpers._
-import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.auth.core.{Assistant, AuthConnector, Enrolment}
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.ApplicationController
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.SessionCache
 import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.start


### PR DESCRIPTION
Changing the order of the checks during authorisation call - https://jira.tools.tax.service.gov.uk/browse/ECC-981.

Previous order:

1. Check User type (Agent check) & email check (checking Cred Role was included in User Type check)
2. Check enrolment

New order:

1. Check User type (Agent check) & email check
2. Check enrolment
3. Organisation Cred Role Assistant check

(as in https://github.com/hmrc/customs-rosm-frontend/pull/62 and https://github.com/hmrc/eori-common-component-frontend/pull/356)