### PR TITLE
Ecc 1232 - Add missing audit event types

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/connector/SubscriptionStatusConnector.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/connector/SubscriptionStatusConnector.scala
@@ -22,6 +22,7 @@ import play.api.libs.json.Json
 import uk.gov.hmrc.eoricommoncomponent.frontend.audit.Auditable
 import uk.gov.hmrc.eoricommoncomponent.frontend.config.AppConfig
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
+import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.events.{
   SubscriptionStatus,
   SubscriptionStatusResult,
@@ -41,7 +42,9 @@ class SubscriptionStatusConnector @Inject() (http: HttpClient, appConfig: AppCon
   private val logger = Logger(this.getClass)
   private val url    = appConfig.getServiceUrl("subscription-status")
 
-  def status(request: SubscriptionStatusQueryParams)(implicit hc: HeaderCarrier): Future[SubscriptionStatusResponse] = {
+  def status(
+    request: SubscriptionStatusQueryParams
+  )(implicit hc: HeaderCarrier, originatingService: Service): Future[SubscriptionStatusResponse] = {
 
     // $COVERAGE-OFF$Loggers
     logger.debug(s"Status SUB01: $url, queryParams: ${request.queryParams} and hc: $hc")
@@ -65,9 +68,9 @@ class SubscriptionStatusConnector @Inject() (http: HttpClient, appConfig: AppCon
     url: String,
     request: SubscriptionStatusQueryParams,
     response: SubscriptionStatusResponseHolder
-  )(implicit hc: HeaderCarrier): Unit = {
+  )(implicit hc: HeaderCarrier, originatingService: Service): Unit = {
 
-    val subscriptionStatusSubmitted = SubscriptionStatusSubmitted(request)
+    val subscriptionStatusSubmitted = SubscriptionStatusSubmitted(request, originatingService.code)
     val subscriptionStatusResult    = SubscriptionStatusResult(response)
 
     audit.sendExtendedDataEvent(

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/ConfirmContactDetailsController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/ConfirmContactDetailsController.scala
@@ -195,7 +195,7 @@ class ConfirmContactDetailsController @Inject() (
   ): Future[Result] =
     detailsCorrect match {
       case Yes =>
-        registrationConfirmService.currentSubscriptionStatus flatMap {
+        registrationConfirmService.currentSubscriptionStatus(hc, service) flatMap {
           case NewSubscription | SubscriptionRejected =>
             onNewSubscription(service, isInReviewMode)
           case SubscriptionProcessing =>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/UserLocationController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/UserLocationController.scala
@@ -77,7 +77,7 @@ class UserLocationController @Inject() (
     request: Request[AnyContent],
     hc: HeaderCarrier
   ) =
-    subscriptionStatusBasedOnSafeId(groupId).map {
+    subscriptionStatusBasedOnSafeId(groupId)(hc, service).map {
       case (NewSubscription | SubscriptionRejected, Some(safeId)) =>
         registrationDisplayService
           .requestDetails(safeId)
@@ -122,7 +122,7 @@ class UserLocationController @Inject() (
       case _                                    => throw new IllegalStateException("User Location not set")
     }
 
-  private def subscriptionStatusBasedOnSafeId(groupId: GroupId)(implicit hc: HeaderCarrier) =
+  private def subscriptionStatusBasedOnSafeId(groupId: GroupId)(implicit hc: HeaderCarrier, service: Service) =
     for {
       mayBeSafeId <- save4LaterService.fetchSafeId(groupId)
       preSubscriptionStatus <- mayBeSafeId match {

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/models/events/CustomsDataStoreUpdate.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/models/events/CustomsDataStoreUpdate.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eoricommoncomponent.frontend.models.events
+
+import play.api.libs.json.Json
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.subscription.CustomsDataStoreRequest
+import uk.gov.hmrc.http.HttpResponse
+
+case class UpdateRequest(eori: String, address: String, timestamp: String)
+
+object UpdateRequest {
+  implicit val format = Json.format[UpdateRequest]
+
+  def apply(request: CustomsDataStoreRequest): UpdateRequest =
+    UpdateRequest(eori = request.eori, address = request.address, timestamp = request.timestamp)
+
+}
+
+case class UpdateResponse(status: String)
+
+object UpdateResponse {
+  implicit val format = Json.format[UpdateResponse]
+
+  def apply(response: HttpResponse): UpdateResponse =
+    UpdateResponse(status = response.status.toString)
+
+}
+
+case class CustomsDataStoreUpdate(request: UpdateRequest, response: UpdateResponse)
+
+object CustomsDataStoreUpdate {
+  implicit val format = Json.format[CustomsDataStoreUpdate]
+}

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/models/events/SubscriptionStatusSubmitted.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/models/events/SubscriptionStatusSubmitted.scala
@@ -23,18 +23,20 @@ case class SubscriptionStatusSubmitted(
   taxPayerId: Option[String],
   safeId: Option[String],
   receiptDate: String,
-  regime: String
+  regime: String,
+  originatingService: String
 )
 
 object SubscriptionStatusSubmitted {
   implicit val format = Json.format[SubscriptionStatusSubmitted]
 
-  def apply(request: SubscriptionStatusQueryParams): SubscriptionStatusSubmitted =
+  def apply(request: SubscriptionStatusQueryParams, originatingService: String): SubscriptionStatusSubmitted =
     SubscriptionStatusSubmitted(
       taxPayerId = if (request.idType == "taxPayerId") Some(request.id) else None,
       safeId = if (request.idType == "SAFE") Some(request.id) else None,
       receiptDate = request.receiptDate.toString,
-      regime = request.regime
+      regime = request.regime,
+      originatingService = originatingService
     )
 
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/RegistrationConfirmService.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/RegistrationConfirmService.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.eoricommoncomponent.frontend.services
 
+import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
+
 import javax.inject.{Inject, Singleton}
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{
   ClearCacheAndRegistrationIdentificationService,
@@ -34,7 +36,7 @@ class RegistrationConfirmService @Inject() (
   val clearDataService: ClearCacheAndRegistrationIdentificationService
 )(implicit ec: ExecutionContext) {
 
-  def currentSubscriptionStatus(implicit hc: HeaderCarrier): Future[PreSubscriptionStatus] =
+  def currentSubscriptionStatus(implicit hc: HeaderCarrier, service: Service): Future[PreSubscriptionStatus] =
     cdsFrontendCache.registrationDetails flatMap { registrationDetails =>
       subscriptionStatusService.getStatus("taxPayerID", registrationDetails.sapNumber.mdgTaxPayerId)
     }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/SubscriptionStatusService.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/SubscriptionStatusService.scala
@@ -19,9 +19,9 @@ package uk.gov.hmrc.eoricommoncomponent.frontend.services
 import javax.inject.{Inject, Singleton}
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-
 import uk.gov.hmrc.eoricommoncomponent.frontend.connector.SubscriptionStatusConnector
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.{Sub01Outcome, SubscriptionStatusQueryParams}
+import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.SessionCache
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -36,7 +36,10 @@ class SubscriptionStatusService @Inject() (
 
   private val dateFormat = DateTimeFormatter.ofPattern("d MMM yyyy")
 
-  def getStatus(idType: String, id: String)(implicit hc: HeaderCarrier): Future[PreSubscriptionStatus] = {
+  def getStatus(idType: String, id: String)(implicit
+    hc: HeaderCarrier,
+    originatingService: Service
+  ): Future[PreSubscriptionStatus] = {
 
     def createRequest =
       SubscriptionStatusQueryParams(requestCommonGenerator.receiptDate, "CDS", idType, id)

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/UserGroupIdSubscriptionStatusCheckService.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/UserGroupIdSubscriptionStatusCheckService.scala
@@ -41,7 +41,7 @@ class UserGroupIdSubscriptionStatusCheckService @Inject() (
           val sameService = cacheIds.serviceCode.contains(service.code)
 
           subscriptionStatusService
-            .getStatus(idType, cacheIds.safeId.id)
+            .getStatus(idType, cacheIds.safeId.id)(hc, service)
             .flatMap { status =>
               if (status != SubscriptionProcessing)
                 if (sameService)

--- a/test/integration/HandleSubscriptionConnectorSpec.scala
+++ b/test/integration/HandleSubscriptionConnectorSpec.scala
@@ -103,7 +103,7 @@ class HandleSubscriptionConnectorSpec extends IntegrationTestsSpec with ScalaFut
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   def requestReceived(inRequest: Request, inResponse: Response): Unit = {
-    logger.asInstanceOf[ch.qos.logback.classic.Logger].setLevel(Level.INFO) // Comment out this line to avoid logging
+    // logger.asInstanceOf[ch.qos.logback.classic.Logger].setLevel(Level.INFO) // Comment out this line to avoid logging
     logger.info("Test logging")
     logger.info(s"WireMock request at URL: ${inRequest.getAbsoluteUrl}")
     logger.info(s"WireMock request headers: ${inRequest.getHeaders}")

--- a/test/integration/HandleSubscriptionConnectorSpec.scala
+++ b/test/integration/HandleSubscriptionConnectorSpec.scala
@@ -16,9 +16,12 @@
 
 package integration
 
+import ch.qos.logback.classic.Level
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, equalToJson, postRequestedFor, urlEqualTo}
+import com.github.tomakehurst.wiremock.http.{Request, Response}
 import org.scalatest.concurrent.ScalaFutures
+import org.slf4j.LoggerFactory
 import play.api.Application
 import play.api.http.HeaderNames
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -30,6 +33,23 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.subscription.Ha
 import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier}
 import util.externalservices.ExternalServicesConfig.{Host, Port}
 import util.externalservices.{AuditService, HandleSubscriptionService}
+
+object HandleSubscriptionConnectorSpec {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  def requestReceived(inRequest: Request, inResponse: Response): Unit = {
+    logger.info("Test logging")
+    logger.info(s"WireMock request at URL: ${inRequest.getAbsoluteUrl}")
+    logger.info(s"WireMock request headers: ${inRequest.getAbsoluteUrl}")
+    logger.info(s"WireMock response body: ${inRequest.getAbsoluteUrl}")
+
+    println("Test logging")
+    println(s"WireMock request at URL: ${inRequest.getAbsoluteUrl}")
+    println(s"WireMock request headers: ${inRequest.getHeaders}")
+    println(s"WireMock response body: ${Json.prettyPrint(Json.parse(inRequest.getBodyAsString))}")
+  }
+
+}
 
 class HandleSubscriptionConnectorSpec extends IntegrationTestsSpec with ScalaFutures {
 
@@ -80,9 +100,21 @@ class HandleSubscriptionConnectorSpec extends IntegrationTestsSpec with ScalaFut
 
   private val handleSubscriptionRequest = serviceRequestJson.as[HandleSubscriptionRequest]
 
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  def requestReceived(inRequest: Request, inResponse: Response): Unit = {
+    logger.asInstanceOf[ch.qos.logback.classic.Logger].setLevel(Level.INFO) // Comment out this line to avoid logging
+    logger.info("Test logging")
+    logger.info(s"WireMock request at URL: ${inRequest.getAbsoluteUrl}")
+    logger.info(s"WireMock request headers: ${inRequest.getHeaders}")
+    logger.info(s"WireMock response body: ${Json.prettyPrint(Json.parse(inRequest.getBodyAsString))}}")
+    logger.info(s"WireMock response headers: ${inRequest.getHeaders}")
+  }
+
   before {
     resetMockServer()
     AuditService.stubAuditService()
+    wireMockServer.addMockServiceRequestListener(requestReceived)
   }
 
   override def beforeAll: Unit =

--- a/test/integration/SubscriptionStatusConnectorSpec.scala
+++ b/test/integration/SubscriptionStatusConnectorSpec.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.domain.{
   SubscriptionStatusResponseHolder,
   TaxPayerId
 }
+import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
 import util.externalservices.ExternalServicesConfig._
 import util.externalservices.{AuditService, SubscriptionStatusMessagingService}
@@ -59,6 +60,7 @@ class SubscriptionStatusConnectorSpec extends IntegrationTestsSpec with ScalaFut
     SubscriptionStatusQueryParams(receiptDate, Regime, "taxPayerID", TaxPayerId(AValidTaxPayerID).mdgTaxPayerId)
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
+  implicit val service: Service  = Service.cds
 
   val responseWithOk: JsValue =
     Json.parse("""

--- a/test/unit/controllers/ConfirmContactDetailsControllerSpec.scala
+++ b/test/unit/controllers/ConfirmContactDetailsControllerSpec.scala
@@ -316,7 +316,7 @@ class ConfirmContactDetailsControllerSpec extends ControllerSpec with BeforeAndA
 
       when(
         mockRegistrationConfirmService
-          .currentSubscriptionStatus(any[HeaderCarrier])
+          .currentSubscriptionStatus(any[HeaderCarrier], any[Service])
       ).thenReturn(Future.successful(SubscriptionRejected))
 
       invokeConfirmContactDetailsWithSelectedOption() { result =>
@@ -337,7 +337,7 @@ class ConfirmContactDetailsControllerSpec extends ControllerSpec with BeforeAndA
     s"redirect to $redirectUrl when subscription status is $subscriptionStatus" in {
       when(mockSessionCache.subscriptionDetails(any[HeaderCarrier]))
         .thenReturn(Future.successful(subscriptionDetailsHolder))
-      when(mockRegistrationConfirmService.currentSubscriptionStatus(any[HeaderCarrier]))
+      when(mockRegistrationConfirmService.currentSubscriptionStatus(any[HeaderCarrier], any[Service]))
         .thenReturn(Future.successful(subscriptionStatus))
       when(mockSessionCache.registrationDetails(any[HeaderCarrier]))
         .thenReturn(Future.successful(organisationRegistrationDetails))
@@ -589,7 +589,7 @@ class ConfirmContactDetailsControllerSpec extends ControllerSpec with BeforeAndA
   private def mockNewSubscriptionFromSubscriptionStatus() =
     when(
       mockRegistrationConfirmService
-        .currentSubscriptionStatus(any[HeaderCarrier])
+        .currentSubscriptionStatus(any[HeaderCarrier], any[Service])
     ).thenReturn(Future.successful(NewSubscription))
 
   private def mockSubscriptionFlowStart() {

--- a/test/unit/controllers/EmailControllerSpec.scala
+++ b/test/unit/controllers/EmailControllerSpec.scala
@@ -153,7 +153,7 @@ class EmailControllerSpec
     "block when subscription is in progress" in {
       when(mockSave4LaterService.fetchCacheIds(any())(any()))
         .thenReturn(Future.successful(Some(CacheIds(InternalId("int-id"), SafeId("safe-id"), Some("atar")))))
-      when(mockSubscriptionStatusService.getStatus(any(), any())(any()))
+      when(mockSubscriptionStatusService.getStatus(any(), any())(any(), any()))
         .thenReturn(Future.successful(SubscriptionProcessing))
 
       showFormRegister() { result =>

--- a/test/unit/controllers/UserLocationControllerSpec.scala
+++ b/test/unit/controllers/UserLocationControllerSpec.scala
@@ -17,7 +17,6 @@
 package unit.controllers
 
 import java.util.UUID
-
 import common.pages.registration.UserLocationPageOrganisation._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers._
@@ -44,6 +43,7 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.registration.{
   ResponseDetail
 }
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.registration.UserLocation
+import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{RequestSessionData, SessionCache}
 import uk.gov.hmrc.eoricommoncomponent.frontend.services._
 import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.{
@@ -329,7 +329,7 @@ class UserLocationControllerSpec extends ControllerSpec with MockitoSugar with B
           .thenReturn(Future.successful(Some(SafeId("safeid"))))
         when(
           mockSubscriptionStatusService
-            .getStatus(any[String], any[String])(any[HeaderCarrier])
+            .getStatus(any[String], any[String])(any[HeaderCarrier], any[Service])
         ).thenReturn(Future.successful(SubscriptionProcessing))
 
         submitForm(Map(locationFieldName -> selectedOptionValue)) { result =>
@@ -343,7 +343,7 @@ class UserLocationControllerSpec extends ControllerSpec with MockitoSugar with B
           .thenReturn(Future.successful(Some(SafeId("safeid"))))
         when(
           mockSubscriptionStatusService
-            .getStatus(any[String], any[String])(any[HeaderCarrier])
+            .getStatus(any[String], any[String])(any[HeaderCarrier], any[Service])
         ).thenReturn(Future.successful(SubscriptionExists))
 
         submitForm(Map(locationFieldName -> selectedOptionValue)) { result =>
@@ -359,7 +359,7 @@ class UserLocationControllerSpec extends ControllerSpec with MockitoSugar with B
           .thenReturn(Future.successful(Some(SafeId("safeid"))))
         when(
           mockSubscriptionStatusService
-            .getStatus(any[String], any[String])(any[HeaderCarrier])
+            .getStatus(any[String], any[String])(any[HeaderCarrier], any[Service])
         ).thenReturn(Future.successful(SubscriptionRejected))
         when(mockRegistrationDisplayService.requestDetails(any())(any(), any()))
           .thenReturn(
@@ -401,7 +401,7 @@ class UserLocationControllerSpec extends ControllerSpec with MockitoSugar with B
           .thenReturn(Future.successful(Some(SafeId("safeid"))))
         when(
           mockSubscriptionStatusService
-            .getStatus(any[String], any[String])(any[HeaderCarrier])
+            .getStatus(any[String], any[String])(any[HeaderCarrier], any[Service])
         ).thenReturn(Future.successful(NewSubscription))
         when(mockRegistrationDisplayService.requestDetails(any())(any(), any()))
           .thenReturn(

--- a/test/unit/services/RegistrationConfirmServiceSpec.scala
+++ b/test/unit/services/RegistrationConfirmServiceSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.{AnyContent, Request}
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
+import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{
   ClearCacheAndRegistrationIdentificationService,
   RequestSessionData,
@@ -49,6 +50,7 @@ class RegistrationConfirmServiceSpec extends UnitSpec with MockitoSugar with Bef
   )(global)
 
   implicit val hc: HeaderCarrier                = mock[HeaderCarrier]
+  implicit val originatingService: Service      = mock[Service]
   implicit val mockLoggedInUser: LoggedInUser   = mock[LoggedInUser]
   implicit val mockRequest: Request[AnyContent] = mock[Request[AnyContent]]
 
@@ -81,7 +83,7 @@ class RegistrationConfirmServiceSpec extends UnitSpec with MockitoSugar with Bef
       inOrder.verify(mockCdsFrontendDataCache).registrationDetails(meq(hc))
       inOrder
         .verify(mockSubscriptionStatusService)
-        .getStatus(meq("taxPayerID"), meq(TaxPayerId(sapNumber).mdgTaxPayerId))(meq(hc))
+        .getStatus(meq("taxPayerID"), meq(TaxPayerId(sapNumber).mdgTaxPayerId))(meq(hc), meq(originatingService))
     }
 
     "return expected status for EU Individual registered without ID when subscription status is new" in {
@@ -118,7 +120,7 @@ class RegistrationConfirmServiceSpec extends UnitSpec with MockitoSugar with Bef
       inOrder.verify(mockCdsFrontendDataCache).registrationDetails(meq(hc))
       inOrder
         .verify(mockSubscriptionStatusService)
-        .getStatus(meq("taxPayerID"), meq(TaxPayerId(sapNumber).mdgTaxPayerId))(meq(hc))
+        .getStatus(meq("taxPayerID"), meq(TaxPayerId(sapNumber).mdgTaxPayerId))(meq(hc), meq(originatingService))
       inOrder.verifyNoMoreInteractions()
     }
 
@@ -133,7 +135,7 @@ class RegistrationConfirmServiceSpec extends UnitSpec with MockitoSugar with Bef
       inOrder.verify(mockCdsFrontendDataCache).registrationDetails(meq(hc))
       inOrder
         .verify(mockSubscriptionStatusService)
-        .getStatus(meq("taxPayerID"), meq(TaxPayerId(sapNumber).mdgTaxPayerId))(meq(hc))
+        .getStatus(meq("taxPayerID"), meq(TaxPayerId(sapNumber).mdgTaxPayerId))(meq(hc), meq(originatingService))
       inOrder.verifyNoMoreInteractions()
     }
 
@@ -150,7 +152,10 @@ class RegistrationConfirmServiceSpec extends UnitSpec with MockitoSugar with Bef
     "propagate SubscriptionStatusService access error" in {
       mockGetStatus(mock[PreSubscriptionStatus])
       when(
-        mockSubscriptionStatusService.getStatus(meq("taxPayerID"), meq(TaxPayerId(sapNumber).mdgTaxPayerId))(meq(hc))
+        mockSubscriptionStatusService.getStatus(meq("taxPayerID"), meq(TaxPayerId(sapNumber).mdgTaxPayerId))(
+          meq(hc),
+          meq(originatingService)
+        )
       ).thenReturn(Future.failed(emulatedFailure))
 
       val caught = intercept[Exception] {
@@ -163,7 +168,10 @@ class RegistrationConfirmServiceSpec extends UnitSpec with MockitoSugar with Bef
       when(mockRegistrationDetails.sapNumber).thenReturn(TaxPayerId(sapNumber))
       when(mockCdsFrontendDataCache.registrationDetails(meq(hc))).thenReturn(Future.successful(mockRegistrationDetails))
       when(
-        mockSubscriptionStatusService.getStatus(meq("taxPayerID"), meq(TaxPayerId(sapNumber).mdgTaxPayerId))(meq(hc))
+        mockSubscriptionStatusService.getStatus(meq("taxPayerID"), meq(TaxPayerId(sapNumber).mdgTaxPayerId))(
+          meq(hc),
+          meq(originatingService)
+        )
       ).thenReturn(Future.successful(expectedResult))
 
     }

--- a/test/unit/services/SubscriptionStatusServiceSpec.scala
+++ b/test/unit/services/SubscriptionStatusServiceSpec.scala
@@ -17,6 +17,7 @@
 package unit.services
 
 import base.UnitSpec
+
 import java.time.LocalDateTime
 import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
@@ -34,6 +35,7 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.domain.{
   SubscriptionStatusResponseHolder,
   TaxPayerId
 }
+import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.SessionCache
 import uk.gov.hmrc.eoricommoncomponent.frontend.services._
 import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
@@ -56,7 +58,8 @@ class SubscriptionStatusServiceSpec extends UnitSpec with MockitoSugar with Befo
   lazy val service =
     new SubscriptionStatusService(mockConnector, mockRequestCommonGenerator, mockSessionCache)(global)
 
-  implicit val hc: HeaderCarrier = HeaderCarrier()
+  implicit val hc: HeaderCarrier           = HeaderCarrier()
+  implicit val priginatingService: Service = Service.cds
 
   override protected def beforeEach() {
     reset(mockConfig)
@@ -79,7 +82,7 @@ class SubscriptionStatusServiceSpec extends UnitSpec with MockitoSugar with Befo
 
     forAll(statusesWithoutEori) { (status, statusObject: PreSubscriptionStatus) =>
       s"return $statusObject when response status is $status" in {
-        when(mockConnector.status(meq(request))(any[HeaderCarrier])).thenReturn(
+        when(mockConnector.status(meq(request))(any[HeaderCarrier], any[Service])).thenReturn(
           Future.successful(responseHolderWithStatusAndProcessingDateWithoutEori(status).subscriptionStatusResponse)
         )
         when(mockRequestCommonGenerator.receiptDate).thenReturn(receiptDate)
@@ -89,7 +92,7 @@ class SubscriptionStatusServiceSpec extends UnitSpec with MockitoSugar with Befo
     }
 
     "store processing date in cache" in {
-      when(mockConnector.status(meq(request))(any[HeaderCarrier])).thenReturn(
+      when(mockConnector.status(meq(request))(any[HeaderCarrier], any[Service])).thenReturn(
         Future.successful(
           responseHolderWithStatusAndProcessingDateWithoutEori("01", "2018-05-22T09:30:00Z").subscriptionStatusResponse
         )
@@ -102,7 +105,7 @@ class SubscriptionStatusServiceSpec extends UnitSpec with MockitoSugar with Befo
     }
 
     "return failed future for getStatus when connector fails with INTERNAL_SERVER_ERROR" in {
-      when(mockConnector.status(any[SubscriptionStatusQueryParams])(any[HeaderCarrier]))
+      when(mockConnector.status(any[SubscriptionStatusQueryParams])(any[HeaderCarrier], any[Service]))
         .thenReturn(Future.failed(UpstreamErrorResponse("failure", INTERNAL_SERVER_ERROR, 1)))
 
       val caught = intercept[UpstreamErrorResponse] {
@@ -113,7 +116,7 @@ class SubscriptionStatusServiceSpec extends UnitSpec with MockitoSugar with Befo
     }
 
     "return failed future for getStatus when connector fails with BAD_REQUEST" in {
-      when(mockConnector.status(any[SubscriptionStatusQueryParams])(any[HeaderCarrier]))
+      when(mockConnector.status(any[SubscriptionStatusQueryParams])(any[HeaderCarrier], any[Service]))
         .thenReturn(Future.failed(UpstreamErrorResponse("failure", BAD_REQUEST, 1)))
 
       val caught = intercept[UpstreamErrorResponse] {

--- a/test/unit/services/UserGroupIdSubscriptionStatusCheckServiceSpec.scala
+++ b/test/unit/services/UserGroupIdSubscriptionStatusCheckServiceSpec.scala
@@ -27,6 +27,7 @@ import play.api.mvc.Result
 import play.api.mvc.Results.Redirect
 import play.api.test.Helpers.LOCATION
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.{CacheIds, GroupId, InternalId, SafeId}
+import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.{
   NewSubscription,
   PreSubscriptionStatus,
@@ -77,7 +78,7 @@ class UserGroupIdSubscriptionStatusCheckServiceSpec
         mockSave4LaterService
           .fetchCacheIds(any())(any[HeaderCarrier])
       ).thenReturn(Future.successful(Some(cacheIds.copy(serviceCode = Some("otherService")))))
-      when(mockSubscriptionStatusService.getStatus(any[String], any[String])(any[HeaderCarrier]))
+      when(mockSubscriptionStatusService.getStatus(any[String], any[String])(any[HeaderCarrier], any[Service]))
         .thenReturn(Future.successful(SubscriptionProcessing))
 
       val result: Result = service
@@ -94,7 +95,7 @@ class UserGroupIdSubscriptionStatusCheckServiceSpec
         mockSave4LaterService
           .fetchCacheIds(any())(any[HeaderCarrier])
       ).thenReturn(Future.successful(Some(cacheIds.copy(internalId = InternalId("otherUserInternalId")))))
-      when(mockSubscriptionStatusService.getStatus(any[String], any[String])(any[HeaderCarrier]))
+      when(mockSubscriptionStatusService.getStatus(any[String], any[String])(any[HeaderCarrier], any[Service]))
         .thenReturn(Future.successful(SubscriptionProcessing))
 
       val result: Result = service
@@ -111,7 +112,7 @@ class UserGroupIdSubscriptionStatusCheckServiceSpec
         mockSave4LaterService
           .fetchCacheIds(any())(any[HeaderCarrier])
       ).thenReturn(Future.successful(Some(cacheIds.copy(serviceCode = Some(atarService.code)))))
-      when(mockSubscriptionStatusService.getStatus(any[String], any[String])(any[HeaderCarrier]))
+      when(mockSubscriptionStatusService.getStatus(any[String], any[String])(any[HeaderCarrier], any[Service]))
         .thenReturn(Future.successful(SubscriptionProcessing))
 
       val result: Result = service
@@ -143,7 +144,7 @@ class UserGroupIdSubscriptionStatusCheckServiceSpec
         mockSave4LaterService
           .fetchCacheIds(any())(any[HeaderCarrier])
       ).thenReturn(Future.successful(Some(cacheIds.copy(serviceCode = Some("other")))))
-      when(mockSubscriptionStatusService.getStatus(any[String], any[String])(any[HeaderCarrier]))
+      when(mockSubscriptionStatusService.getStatus(any[String], any[String])(any[HeaderCarrier], any[Service]))
         .thenReturn(Future.successful(NewSubscription))
       when(mockSave4LaterService.deleteCacheIds(any())(any[HeaderCarrier])).thenReturn(Future.successful(()))
 
@@ -176,7 +177,7 @@ class UserGroupIdSubscriptionStatusCheckServiceSpec
       mockSave4LaterService
         .fetchCacheIds(any())(any[HeaderCarrier])
     ).thenReturn(Future.successful(Some(cacheIds)))
-    when(mockSubscriptionStatusService.getStatus(any[String], any[String])(any[HeaderCarrier]))
+    when(mockSubscriptionStatusService.getStatus(any[String], any[String])(any[HeaderCarrier], any[Service]))
       .thenReturn(Future.successful(status))
     when(mockSave4LaterService.deleteCachedGroupId(any())(any[HeaderCarrier])).thenReturn(Future.successful(()))
 


### PR DESCRIPTION
Ensure that the following list of events exist in the code: https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?pageId=500105683

Added facility to log audit events in acceptance tests.