### PR TITLE
ECC-1008: Metrics for registration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,7 @@ lazy val scoverageSettings = {
 scalastyleConfig := baseDirectory.value / "project" / "scalastyle-config.xml"
 
 val compileDependencies = Seq(
-  "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % "5.6.0",
+  "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % "7.0.0",
   "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.10.0-play-28",
   "uk.gov.hmrc"       %% "domain"                        % "8.1.0-play-28",
   "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"            % "0.71.0",

--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,7 @@ lazy val scoverageSettings = {
 scalastyleConfig := baseDirectory.value / "project" / "scalastyle-config.xml"
 
 val compileDependencies = Seq(
-  "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % "7.0.0",
+  "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % "5.6.0",
   "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.10.0-play-28",
   "uk.gov.hmrc"       %% "domain"                        % "8.1.0-play-28",
   "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"            % "0.71.0",

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -203,4 +203,6 @@ GET         /customs-registration-services/:service/register/you-cannot-change-a
 
 GET         /customs-registration-services/:service/register/address-invalid                     @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.AddressInvalidController.page(service: Service)
 
+GET         /admin/metrics                                                                                @com.kenshoo.play.metrics.MetricsController.metrics
+
 ->          /                                                                                            health.Routes


### PR DESCRIPTION
Did not add play.modules.enabled += "com.kenshoo.play.metrics.PlayModule" back in as it is already configured within bootstrap-frontend-play-28 which is also required for uk.gov.hmrc.play.audit.AuditModule