### PR TITLE
Ecc 1440

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/Sub02Controller.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/Sub02Controller.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.eoricommoncomponent.frontend.controllers
 
-import javax.inject.{Inject, Singleton}
 import play.api.Logger
 import play.api.mvc._
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.auth.{AuthAction, EnrolmentExtractor}
@@ -24,17 +23,11 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes._
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.subscription.SubscriptionCreateResponse._
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
-import uk.gov.hmrc.eoricommoncomponent.frontend.services.{
-  CdsSubscriber,
-  SubscriptionDetailsService,
-  SubscriptionFailed,
-  SubscriptionPending,
-  SubscriptionSuccessful
-}
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{RequestSessionData, SessionCache}
-import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.xi_eori_guidance
+import uk.gov.hmrc.eoricommoncomponent.frontend.services._
 import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/forms/models/AddressViewModel.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/forms/models/AddressViewModel.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.eoricommoncomponent.frontend.forms.models
 
 import play.api.libs.json.Json
+import play.twirl.api.utils.StringEscapeUtils
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.Address
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.AddressDetails
 
@@ -32,7 +33,12 @@ object AddressViewModel {
   val townCityMaxLength            = 35
 
   def apply(street: String, city: String, postcode: Option[String], countryCode: String): AddressViewModel =
-    new AddressViewModel(street.trim, city.trim, postcode.map(_.trim), countryCode)
+    new AddressViewModel(
+      StringEscapeUtils.escapeXml11(street.trim),
+      StringEscapeUtils.escapeXml11(city.trim),
+      postcode.map(_.trim),
+      countryCode
+    )
 
   def apply(sixLineAddress: Address): AddressViewModel = {
     val line1 = (sixLineAddress.addressLine1.trim.take(sixLineAddressLine1MaxLength) + " " + sixLineAddress.addressLine2
@@ -42,7 +48,12 @@ object AddressViewModel {
     val townCity    = sixLineAddress.addressLine3.getOrElse("").trim.take(townCityMaxLength)
     val postCode    = sixLineAddress.postalCode.map(_.trim)
     val countryCode = sixLineAddress.countryCode
-    AddressViewModel(line1, townCity, postCode, countryCode)
+    AddressViewModel(
+      StringEscapeUtils.escapeXml11(line1),
+      StringEscapeUtils.escapeXml11(townCity),
+      postCode,
+      countryCode
+    )
   }
 
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/forms/models/AddressViewModel.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/forms/models/AddressViewModel.scala
@@ -51,8 +51,8 @@ object AddressViewModel {
     AddressViewModel(
       StringEscapeUtils.escapeXml11(line1),
       StringEscapeUtils.escapeXml11(townCity),
-      postCode,
-      countryCode
+      postCode.map(StringEscapeUtils.escapeXml11(_)),
+      StringEscapeUtils.escapeXml11(countryCode)
     )
   }
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/check_your_details_register.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/check_your_details_register.scala.html
@@ -27,7 +27,7 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
 @import uk.gov.hmrc.govukfrontend.views.html.components.{GovukButton, GovukSummaryList}
 @import uk.gov.hmrc.govukfrontend.views.Aliases.{Button, Text, SummaryListRow, SummaryList, Key, Value, HtmlContent, Actions, ActionItem}
-
+@import play.twirl.api.utils.StringEscapeUtils
 
 @this(layout_di: layout, dateFormatter: DateFormatter, govukButton: GovukButton, govukSummaryList : GovukSummaryList)
 
@@ -203,24 +203,24 @@
 }
 
 @addressViewModelHtml(ad: AddressViewModel) = {
-    @helpers.noMarginParagraph(ad.street)
-    @helpers.noMarginParagraph(ad.city)
-    @ad.postcode.map(helpers.noMarginParagraph(_))
-    @transformCountryCodeToOptionalLabel(Some(ad.countryCode)).map(helpers.noMarginParagraph(_))
+    @helpers.noMarginParagraph(StringEscapeUtils.escapeXml11(ad.street))
+    @helpers.noMarginParagraph(StringEscapeUtils.escapeXml11(ad.city))
+    @ad.postcode.map(s => helpers.noMarginParagraph(StringEscapeUtils.escapeXml11(s)))
+    @transformCountryCodeToOptionalLabel(Some(ad.countryCode)).map(s =>helpers.noMarginParagraph(StringEscapeUtils.escapeXml11(s)))
 }
 @addressHtml(ad: Address) = {
-    @helpers.noMarginParagraph(ad.addressLine1)
-    @ad.addressLine2.map(helpers.noMarginParagraph(_))
-    @ad.addressLine3.map(helpers.noMarginParagraph(_))
-    @ad.addressLine4.map(helpers.noMarginParagraph(_))
-    @ad.postalCode.map(helpers.noMarginParagraph(_))
-    @transformCountryCodeToOptionalLabel(Some(ad.countryCode)).map(helpers.noMarginParagraph(_))
+    @helpers.noMarginParagraph(StringEscapeUtils.escapeXml11(ad.addressLine1))
+    @ad.addressLine2.map(s =>helpers.noMarginParagraph(StringEscapeUtils.escapeXml11(s)))
+    @ad.addressLine3.map(s =>helpers.noMarginParagraph(StringEscapeUtils.escapeXml11(s)))
+    @ad.addressLine4.map(s =>helpers.noMarginParagraph(StringEscapeUtils.escapeXml11(s)))
+    @ad.postalCode.map(s =>helpers.noMarginParagraph(StringEscapeUtils.escapeXml11(s)))
+    @transformCountryCodeToOptionalLabel(Some(ad.countryCode)).map(s => helpers.noMarginParagraph(StringEscapeUtils.escapeXml11(s)))
 }
 @contactDetailsHtml(details: ContactDetailsModel) = {
-    @details.street.map(helpers.noMarginParagraph(_))
-    @details.city.map(helpers.noMarginParagraph(_))
-    @details.postcode.map(helpers.noMarginParagraph(_))
-    @transformCountryCodeToOptionalLabel(details.countryCode).map(helpers.noMarginParagraph(_))
+    @details.street.map(s => helpers.noMarginParagraph(StringEscapeUtils.escapeXml11(s)))
+    @details.city.map(s => helpers.noMarginParagraph(StringEscapeUtils.escapeXml11(s)))
+    @details.postcode.map(s =>helpers.noMarginParagraph(StringEscapeUtils.escapeXml11(s)))
+    @transformCountryCodeToOptionalLabel(details.countryCode).map(s => helpers.noMarginParagraph(StringEscapeUtils.escapeXml11(s)))
 }
 
 @summaryListRow(key: String, value: Option[Html], call: Option[Call] = None, classes: String = "") = @{
@@ -256,7 +256,7 @@
     if(isIndividual || isSoleTrader) {
         Seq(summaryListRow(
             key = messages("subscription.check-your-details.full-name.label"),
-            value = Some(Html(individualName)),
+            value = Some(Html(StringEscapeUtils.escapeXml11(individualName))),
             call = if(!isUserIdentifiedByRegService) Some(RowIndividualNameDateOfBirthController.reviewForm(orgType, service)) else None
         ),
             summaryListRow(
@@ -271,7 +271,7 @@
     if(!isIndividual && !isSoleTrader) {
         Seq(summaryListRow(
             key = orgNameLabel,
-            value = Some(Html(orgName)),
+            value = Some(Html(StringEscapeUtils.escapeXml11(orgName))),
             call = if(!isUserIdentifiedByRegService) Some(WhatIsYourOrgNameController.showForm(isInReviewMode = true, organisationType = orgType, service)) else None
         ))
     } else Seq.empty[SummaryListRow]
@@ -352,7 +352,7 @@
     Seq(subscription.contactDetails.map { cd =>
         summaryListRow(
             key = messages("cds.form.check-answers.contact-name"),
-            value = Some(Html(cd.fullName)),
+            value = Some(Html(StringEscapeUtils.escapeXml11(cd.fullName))),
             call = Some(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes.ContactDetailsController.reviewForm(service))
             )
         }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/check_your_details_register.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/check_your_details_register.scala.html
@@ -271,7 +271,7 @@
     if(!isIndividual && !isSoleTrader) {
         Seq(summaryListRow(
             key = orgNameLabel,
-            value = Some(Html(StringEscapeUtils.escapeXml11(orgName))),
+            value = Some(Text(orgName).asHtml),
             call = if(!isUserIdentifiedByRegService) Some(WhatIsYourOrgNameController.showForm(isInReviewMode = true, organisationType = orgType, service)) else None
         ))
     } else Seq.empty[SummaryListRow]
@@ -352,7 +352,7 @@
     Seq(subscription.contactDetails.map { cd =>
         summaryListRow(
             key = messages("cds.form.check-answers.contact-name"),
-            value = Some(Html(StringEscapeUtils.escapeXml11(cd.fullName))),
+            value = Some(Text(cd.fullName).asHtml),
             call = Some(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes.ContactDetailsController.reviewForm(service))
             )
         }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/check_your_details_register.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/check_your_details_register.scala.html
@@ -154,6 +154,7 @@
 @individualName = @{
     subscription.nameDobDetails match {
         case Some(nameDobDetails) => nameDobDetails.name
+        case _ if registration.name == null  => ""
         case _ =>  registration.name
     }
 }
@@ -161,7 +162,8 @@
 @orgName = @{
     subscription.nameOrganisationDetails match {
         case Some(nameOrgDetails) => nameOrgDetails.name
-        case _ =>  subscription.name
+        case _ if subscription.name == null  => ""
+        case _ => subscription.name
     }
 }
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/standalone_subscription_outcome.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/standalone_subscription_outcome.scala.html
@@ -22,10 +22,9 @@
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{Text, HtmlContent}
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.panel.Panel
 @import uk.gov.hmrc.eoricommoncomponent.frontend.config.AppConfig
-@import org.apache.commons.text.StringEscapeUtils
+@import play.twirl.api.utils.StringEscapeUtils
 
 @this(layout_di: layout, feedback_di: helpers.feedback, help_di: partials.if_you_need_help, dateFormatter: DateFormatter, govukPanel: GovukPanel, appConfig: AppConfig)
-
 @(eori: String, name: String, processedDate: String)(implicit messages: Messages, request: Request[_])
 
 @checkEORILink = {

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/standalone_subscription_outcome.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/standalone_subscription_outcome.scala.html
@@ -22,6 +22,7 @@
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{Text, HtmlContent}
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.panel.Panel
 @import uk.gov.hmrc.eoricommoncomponent.frontend.config.AppConfig
+@import org.apache.commons.text.StringEscapeUtils
 
 @this(layout_di: layout, feedback_di: helpers.feedback, help_di: partials.if_you_need_help, dateFormatter: DateFormatter, govukPanel: GovukPanel, appConfig: AppConfig)
 
@@ -34,7 +35,7 @@
 @layout_di(messages("cds.reg.existing.outcomes.success.heading.part1.standalone", name, eori), displayBackLink = false) {
 <div>
     @govukPanel(Panel(
-        title = HtmlContent(messages("cds.reg.existing.outcomes.success.heading.part1.standalone", name, eori)),
+        title = HtmlContent(messages("cds.reg.existing.outcomes.success.heading.part1.standalone", StringEscapeUtils.escapeXml11(name), eori)),
         content = HtmlContent(s""" <h2 id="issued-date" class="govuk-heading-s govuk-panel--confirmation">${messages("cds.subscription.outcomes.success.issued")} ${dateFormatter.format(processedDate)}""")
     ))
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/sub01_outcome_rejected.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/sub01_outcome_rejected.scala.html
@@ -20,7 +20,7 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.JourneyExtractor
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
-
+@import org.apache.commons.text.StringEscapeUtils
 
 @this(layout_di: layout, feedback_di: helpers.feedback, help_di: partials.if_you_need_help, dateFormatter: DateFormatter)
 @(name: Option[String], processedDate: String, service: Service)(implicit messages: Messages, request: Request[_])
@@ -31,7 +31,7 @@
 }
 
 @heading = {@name match {
-    case Some(user) => {@messages(s"cds.sub01.outcome.rejected.$journeyKey.heading", longName, user)}
+    case Some(user) => {@messages(s"cds.sub01.outcome.rejected.$journeyKey.heading", longName, StringEscapeUtils.escapeXml11(user))}
     case None => {@messages(s"cds.sub01.outcome.rejected.$journeyKey.heading-noname", longName)}
   }
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/sub01_outcome_rejected.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/sub01_outcome_rejected.scala.html
@@ -20,7 +20,7 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.JourneyExtractor
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
-@import org.apache.commons.text.StringEscapeUtils
+@import play.twirl.api.utils.StringEscapeUtils
 
 @this(layout_di: layout, feedback_di: helpers.feedback, help_di: partials.if_you_need_help, dateFormatter: DateFormatter)
 @(name: Option[String], processedDate: String, service: Service)(implicit messages: Messages, request: Request[_])

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/sub02_eori_already_exists.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/sub02_eori_already_exists.scala.html
@@ -16,6 +16,7 @@
 
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
+@import org.apache.commons.text.StringEscapeUtils
 
 
 @this(layout_di: layout, feedback_di: helpers.feedback, dateFormatter: DateFormatter)
@@ -25,7 +26,7 @@
 @layout_di(messages("cds.sub02.outcome.eori-already-exists.title")) {
     <div>
         <div>
-            <h1 id="page-heading" class="govuk-heading-xl">@messages("cds.sub02.outcome.eori-already-exists.heading", name)</h1>
+            <h1 id="page-heading" class="govuk-heading-xl">@messages("cds.sub02.outcome.eori-already-exists.heading", StringEscapeUtils.escapeXml11(name))</h1>
             <p class="govuk-heading-m" id="processed-date">@messages("cds.sub02.outcome.eori-already-exists.received", dateFormatter.format(processedDate))</p>
         </div>
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/sub02_eori_already_exists.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/sub02_eori_already_exists.scala.html
@@ -16,7 +16,7 @@
 
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
-@import org.apache.commons.text.StringEscapeUtils
+@import play.twirl.api.utils.StringEscapeUtils
 
 
 @this(layout_di: layout, feedback_di: helpers.feedback, dateFormatter: DateFormatter)

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/sub02_subscription_in_progress.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/sub02_subscription_in_progress.scala.html
@@ -18,6 +18,7 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.JourneyStatus
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.ServiceName.service
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
+@import org.apache.commons.text.StringEscapeUtils
 
 
 @this(layout_di: layout, feedback_di: helpers.feedback, dateFormatter: DateFormatter)
@@ -27,7 +28,7 @@
 @layout_di(messages("cds.sub02.outcome.subscription-in-progress.title")) {
     <div>
         <div class="govuk-box-highlight">
-            <h1 id="page-heading" class="govuk-heading-xl">@messages("cds.sub02.outcome.subscription-in-progress.heading", name)</h1>
+            <h1 id="page-heading" class="govuk-heading-xl">@messages("cds.sub02.outcome.subscription-in-progress.heading", StringEscapeUtils.escapeXml11(name))</h1>
             <p id="processed-date" class="govuk-heading-m">@messages("cds.sub02.outcome.subscription-in-progress.received", dateFormatter.format(processedDate))</p>
         </div>
         <h2 id="what-happens-next" class="govuk-heading-m">@messages("cds.sub02.outcome.subscription-in-progress.what-happens-next")</h2>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/sub02_subscription_in_progress.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/sub02_subscription_in_progress.scala.html
@@ -18,7 +18,7 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.JourneyStatus
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.ServiceName.service
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
-@import org.apache.commons.text.StringEscapeUtils
+@import play.twirl.api.utils.StringEscapeUtils
 
 
 @this(layout_di: layout, feedback_di: helpers.feedback, dateFormatter: DateFormatter)

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription_download.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription_download.scala.html
@@ -18,6 +18,7 @@
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.panel.Panel
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
+@import org.apache.commons.text.StringEscapeUtils
 
 @this(govukPanel: GovukPanel,dateFormatter: DateFormatter)
 @(eori: String, name: String, processedDate: String)(implicit messages: Messages)
@@ -194,7 +195,7 @@
 </div>
 <div>
     @govukPanel(Panel(
-        title = HtmlContent(s"""${messages("cds.reg.existing.outcomes.success.heading.part1")} $name"""),
+        title = HtmlContent(s"""${messages("cds.reg.existing.outcomes.success.heading.part1")} ${StringEscapeUtils.escapeXml11(name)}"""),
         content = HtmlContent(s""" <h5 style="color:white" id="issued-date" class="govuk-heading-s"><strong>${messages("cds.subscription.outcomes.success.issued")} ${dateFormatter.format(processedDate)}</strong></h5><p style="color:white" id="eori" class="govuk-heading-m govuk-!-font-size-27">${messages("cds.subscription.outcomes.success.eori")} <br>$eori</p>""")
     ))
 </div>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription_download.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription_download.scala.html
@@ -18,7 +18,7 @@
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.panel.Panel
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
-@import org.apache.commons.text.StringEscapeUtils
+@import play.twirl.api.utils.StringEscapeUtils
 
 @this(govukPanel: GovukPanel,dateFormatter: DateFormatter)
 @(eori: String, name: String, processedDate: String)(implicit messages: Messages)

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription_outcome.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription_outcome.scala.html
@@ -23,7 +23,7 @@
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.panel.Panel
 @import uk.gov.hmrc.eoricommoncomponent.frontend.config.AppConfig
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
-@import org.apache.commons.text.StringEscapeUtils
+@import play.twirl.api.utils.StringEscapeUtils
 
 @this(layout_di: layout, feedback_di: helpers.feedback, help_di: partials.if_you_need_help, dateFormatter: DateFormatter, govukPanel: GovukPanel, appConfig: AppConfig)
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription_outcome.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription_outcome.scala.html
@@ -23,6 +23,7 @@
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.panel.Panel
 @import uk.gov.hmrc.eoricommoncomponent.frontend.config.AppConfig
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
+@import org.apache.commons.text.StringEscapeUtils
 
 @this(layout_di: layout, feedback_di: helpers.feedback, help_di: partials.if_you_need_help, dateFormatter: DateFormatter, govukPanel: GovukPanel, appConfig: AppConfig)
 
@@ -32,10 +33,10 @@
 <a class="govuk-link" href=@appConfig.checkEORINumber target="_blank" rel="noopener noreferrer">@messages("cds.subscription.outcomes.success.extra.information2")</a>
 }
 
-@layout_di(s"""${messages("cds.reg.existing.outcomes.success.heading.part1")} $name""", displayBackLink = false) {
+@layout_di(s"""${messages("cds.reg.existing.outcomes.success.heading.part1")} ${StringEscapeUtils.escapeXml11(name)}""", displayBackLink = false) {
 <div>
     @govukPanel(Panel(
-        title = HtmlContent(s"""${messages("cds.reg.existing.outcomes.success.heading.part1")} $name"""),
+        title = HtmlContent(s"""${messages("cds.reg.existing.outcomes.success.heading.part1")} ${StringEscapeUtils.escapeXml11(name)}"""),
         content = HtmlContent(s""" <h2 id="issued-date" class="govuk-heading-s govuk-panel--confirmation">${messages("cds.subscription.outcomes.success.issued")} ${dateFormatter.format(processedDate)}</h2><p id="eori-number" class="govuk-heading-m govuk-panel--confirmation govuk-!-font-size-27">${messages("cds.subscription.outcomes.success.eori")} <br>$eori</p>""")
     ))
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription_outcome_fail.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription_outcome_fail.scala.html
@@ -19,7 +19,7 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.JourneyStatus
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
-@import org.apache.commons.text.StringEscapeUtils
+@import play.twirl.api.utils.StringEscapeUtils
 
 
 @this(layout_di: layout, feedback_di: helpers.feedback, help_di: partials.if_you_need_help, dateFormatter: DateFormatter)

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription_outcome_fail.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription_outcome_fail.scala.html
@@ -19,6 +19,7 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.JourneyStatus
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
+@import org.apache.commons.text.StringEscapeUtils
 
 
 @this(layout_di: layout, feedback_di: helpers.feedback, help_di: partials.if_you_need_help, dateFormatter: DateFormatter)
@@ -27,7 +28,7 @@
 @layout_di(messages("cds.subscription.outcomes.rejected.title", shortName), suppressTelephoneNumberDetection = false) {
 <div>
     <div>
-        <h1 id="page-heading" class="govuk-heading-xl">@messages("cds.subscription.outcomes.rejected.heading", shortName, name) </h1>
+        <h1 id="page-heading" class="govuk-heading-xl">@messages("cds.subscription.outcomes.rejected.heading", shortName, StringEscapeUtils.escapeXml11(name)) </h1>
         <div class="govuk-heading-m" id="active-from">@messages("cds.subscription.outcomes.rejected.received", dateFormatter.format(processedDate))</div>
     </div>
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription_outcome_pending.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription_outcome_pending.scala.html
@@ -19,6 +19,7 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.JourneyStatus
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
+@import org.apache.commons.text.StringEscapeUtils
 
 
 @this(layout_di: layout, feedback_di: helpers.feedback, help_di: partials.if_you_need_help, dateFormatter: DateFormatter)
@@ -27,7 +28,7 @@
 @layout_di(messages("cds.subscription.outcomes.in-processing.title"), suppressTelephoneNumberDetection = false) {
     <div>
         <div>
-            <h1 id="page-heading" class="govuk-heading-xl">@messages("cds.subscription.outcomes.in-processing.heading", name)</h1>
+            <h1 id="page-heading" class="govuk-heading-xl">@messages("cds.subscription.outcomes.in-processing.heading", StringEscapeUtils.escapeXml11(name))</h1>
             <div class="govuk-heading-m" id="active-from">@messages("cds.subscription.outcomes.in-processing.received", dateFormatter.format(processedDate))</div>
             <div class="govuk-heading-m" id="eori-number">@messages("cds.subscription.outcomes.inprocessing.eori", eori)</div>
         </div>

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription_outcome_pending.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/subscription_outcome_pending.scala.html
@@ -19,10 +19,11 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.JourneyStatus
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.DateFormatter
-@import org.apache.commons.text.StringEscapeUtils
+@import play.twirl.api.utils.StringEscapeUtils
 
 
 @this(layout_di: layout, feedback_di: helpers.feedback, help_di: partials.if_you_need_help, dateFormatter: DateFormatter)
+
 @(eori: String, processedDate: String, name: String, service: Service)(implicit messages: Messages, request: Request[_])
 
 @layout_di(messages("cds.subscription.outcomes.in-processing.title"), suppressTelephoneNumberDetection = false) {


### PR DESCRIPTION
Sanitised content prior to display.

The play framework sanitises content by default. Escaping html/xml/javascript type content.

Unfortunately we also dynamically generate html in Scala, which means passing Html typed variables around (including dynamic content).

To get around this I escape databased sourced user content using the Apache commons text library: StringEscapeUtils.