### PR TITLE
Revert "ECC-1500: Updated VAT flow for other journeys"

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/subscription/SubscriptionFlow.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/subscription/SubscriptionFlow.scala
@@ -36,7 +36,6 @@ object SubscriptionFlows {
       SicCodeSubscriptionFlowPage,
       EoriConsentSubscriptionFlowPage,
       VatRegisteredUkSubscriptionFlowPage,
-      VatGroupFlowPage,
       VatDetailsSubscriptionFlowPage,
       ContactDetailsSubscriptionFlowPageGetEori,
       ContactAddressSubscriptionFlowPageGetEori
@@ -62,7 +61,6 @@ object SubscriptionFlows {
       SicCodeSubscriptionFlowPage,
       EoriConsentSubscriptionFlowPage,
       VatRegisteredUkSubscriptionFlowPage,
-      VatGroupFlowPage,
       VatDetailsSubscriptionFlowPage,
       ContactDetailsSubscriptionFlowPageGetEori,
       ContactAddressSubscriptionFlowPageGetEori
@@ -83,7 +81,6 @@ object SubscriptionFlows {
       SicCodeSubscriptionFlowPage,
       EoriConsentSubscriptionFlowPage,
       VatRegisteredUkSubscriptionFlowPage,
-      VatGroupFlowPage,
       VatDetailsSubscriptionFlowPage,
       ContactDetailsSubscriptionFlowPageGetEori,
       ContactAddressSubscriptionFlowPageGetEori
@@ -96,10 +93,10 @@ object SubscriptionFlows {
       SicCodeSubscriptionFlowPage,
       EoriConsentSubscriptionFlowPage,
       VatRegisteredUkSubscriptionFlowPage,
-      VatGroupFlowPage,
       VatDetailsSubscriptionFlowPage,
       ContactDetailsSubscriptionFlowPageGetEori,
       ContactAddressSubscriptionFlowPageGetEori
+      //VatGroupFlowPage
     )
   )
 

--- a/test/unit/controllers/SubscriptionFlowManagerSpec.scala
+++ b/test/unit/controllers/SubscriptionFlowManagerSpec.scala
@@ -98,33 +98,31 @@ class SubscriptionFlowManagerSpec
         ContactAddressSubscriptionFlowPageGetEori
       ),
       (OrganisationSubscriptionFlow, ContactAddressSubscriptionFlowPageGetEori, 8, 8, ReviewDetailsPageGetYourEORI),
-      (PartnershipSubscriptionFlow, DateOfEstablishmentSubscriptionFlowPage, 1, 8, SicCodeSubscriptionFlowPage),
-      (PartnershipSubscriptionFlow, SicCodeSubscriptionFlowPage, 2, 8, EoriConsentSubscriptionFlowPage),
-      (PartnershipSubscriptionFlow, EoriConsentSubscriptionFlowPage, 3, 8, VatRegisteredUkSubscriptionFlowPage),
-      (PartnershipSubscriptionFlow, VatRegisteredUkSubscriptionFlowPage, 4, 8, VatGroupFlowPage),
-      (PartnershipSubscriptionFlow, VatGroupFlowPage, 5, 8, VatDetailsSubscriptionFlowPage),
-      (PartnershipSubscriptionFlow, VatDetailsSubscriptionFlowPage, 6, 8, ContactDetailsSubscriptionFlowPageGetEori),
+      (PartnershipSubscriptionFlow, DateOfEstablishmentSubscriptionFlowPage, 1, 7, SicCodeSubscriptionFlowPage),
+      (PartnershipSubscriptionFlow, SicCodeSubscriptionFlowPage, 2, 7, EoriConsentSubscriptionFlowPage),
+      (PartnershipSubscriptionFlow, EoriConsentSubscriptionFlowPage, 3, 7, VatRegisteredUkSubscriptionFlowPage),
+      (PartnershipSubscriptionFlow, VatRegisteredUkSubscriptionFlowPage, 4, 7, VatDetailsSubscriptionFlowPage),
+      (PartnershipSubscriptionFlow, VatDetailsSubscriptionFlowPage, 5, 7, ContactDetailsSubscriptionFlowPageGetEori),
       (
         PartnershipSubscriptionFlow,
-        ContactDetailsSubscriptionFlowPageGetEori,
-        7,
-        8,
-        ContactAddressSubscriptionFlowPageGetEori
-      ),
-      (PartnershipSubscriptionFlow, ContactAddressSubscriptionFlowPageGetEori, 8, 8, ReviewDetailsPageGetYourEORI),
-      (SoleTraderSubscriptionFlow, SicCodeSubscriptionFlowPage, 1, 7, EoriConsentSubscriptionFlowPage),
-      (SoleTraderSubscriptionFlow, EoriConsentSubscriptionFlowPage, 2, 7, VatRegisteredUkSubscriptionFlowPage),
-      (SoleTraderSubscriptionFlow, VatRegisteredUkSubscriptionFlowPage, 3, 7, VatGroupFlowPage),
-      (SoleTraderSubscriptionFlow, VatGroupFlowPage, 4, 7, VatDetailsSubscriptionFlowPage),
-      (SoleTraderSubscriptionFlow, VatDetailsSubscriptionFlowPage, 5, 7, ContactDetailsSubscriptionFlowPageGetEori),
-      (
-        SoleTraderSubscriptionFlow,
         ContactDetailsSubscriptionFlowPageGetEori,
         6,
         7,
         ContactAddressSubscriptionFlowPageGetEori
       ),
-      (SoleTraderSubscriptionFlow, ContactAddressSubscriptionFlowPageGetEori, 7, 7, ReviewDetailsPageGetYourEORI),
+      (PartnershipSubscriptionFlow, ContactAddressSubscriptionFlowPageGetEori, 7, 7, ReviewDetailsPageGetYourEORI),
+      (SoleTraderSubscriptionFlow, SicCodeSubscriptionFlowPage, 1, 6, EoriConsentSubscriptionFlowPage),
+      (SoleTraderSubscriptionFlow, EoriConsentSubscriptionFlowPage, 2, 6, VatRegisteredUkSubscriptionFlowPage),
+      (SoleTraderSubscriptionFlow, VatRegisteredUkSubscriptionFlowPage, 3, 6, VatDetailsSubscriptionFlowPage),
+      (SoleTraderSubscriptionFlow, VatDetailsSubscriptionFlowPage, 4, 6, ContactDetailsSubscriptionFlowPageGetEori),
+      (
+        SoleTraderSubscriptionFlow,
+        ContactDetailsSubscriptionFlowPageGetEori,
+        5,
+        6,
+        ContactAddressSubscriptionFlowPageGetEori
+      ),
+      (SoleTraderSubscriptionFlow, ContactAddressSubscriptionFlowPageGetEori, 6, 6, ReviewDetailsPageGetYourEORI),
       (IndividualSubscriptionFlow, EoriConsentSubscriptionFlowPage, 1, 3, ContactDetailsSubscriptionFlowPageGetEori),
       (
         IndividualSubscriptionFlow,
@@ -138,38 +136,43 @@ class SubscriptionFlowManagerSpec
         ThirdCountryOrganisationSubscriptionFlow,
         DateOfEstablishmentSubscriptionFlowPage,
         1,
-        8,
+        7,
         SicCodeSubscriptionFlowPage
       ),
-      (ThirdCountryOrganisationSubscriptionFlow, SicCodeSubscriptionFlowPage, 2, 8, EoriConsentSubscriptionFlowPage),
+      (ThirdCountryOrganisationSubscriptionFlow, SicCodeSubscriptionFlowPage, 2, 7, EoriConsentSubscriptionFlowPage),
       (
         ThirdCountryOrganisationSubscriptionFlow,
         EoriConsentSubscriptionFlowPage,
         3,
-        8,
+        7,
         VatRegisteredUkSubscriptionFlowPage
       ),
-      (ThirdCountryOrganisationSubscriptionFlow, VatRegisteredUkSubscriptionFlowPage, 4, 8, VatGroupFlowPage),
-      (ThirdCountryOrganisationSubscriptionFlow, VatGroupFlowPage, 5, 8, VatDetailsSubscriptionFlowPage),
+      (
+        ThirdCountryOrganisationSubscriptionFlow,
+        VatRegisteredUkSubscriptionFlowPage,
+        4,
+        7,
+        VatDetailsSubscriptionFlowPage
+      ),
       (
         ThirdCountryOrganisationSubscriptionFlow,
         VatDetailsSubscriptionFlowPage,
-        6,
-        8,
+        5,
+        7,
         ContactDetailsSubscriptionFlowPageGetEori
       ),
       (
         ThirdCountryOrganisationSubscriptionFlow,
         ContactDetailsSubscriptionFlowPageGetEori,
+        6,
         7,
-        8,
         ContactAddressSubscriptionFlowPageGetEori
       ),
       (
         ThirdCountryOrganisationSubscriptionFlow,
         ContactAddressSubscriptionFlowPageGetEori,
-        8,
-        8,
+        7,
+        7,
         ReviewDetailsPageGetYourEORI
       ),
       (
@@ -193,35 +196,40 @@ class SubscriptionFlowManagerSpec
         3,
         ContactDetailsSubscriptionFlowPageGetEori
       ),
-      (ThirdCountrySoleTraderSubscriptionFlow, SicCodeSubscriptionFlowPage, 1, 7, EoriConsentSubscriptionFlowPage),
+      (ThirdCountrySoleTraderSubscriptionFlow, SicCodeSubscriptionFlowPage, 1, 6, EoriConsentSubscriptionFlowPage),
       (
         ThirdCountrySoleTraderSubscriptionFlow,
         EoriConsentSubscriptionFlowPage,
         2,
-        7,
+        6,
         VatRegisteredUkSubscriptionFlowPage
       ),
-      (ThirdCountrySoleTraderSubscriptionFlow, VatRegisteredUkSubscriptionFlowPage, 3, 7, VatGroupFlowPage),
-      (ThirdCountrySoleTraderSubscriptionFlow, VatGroupFlowPage, 4, 7, VatDetailsSubscriptionFlowPage),
+      (
+        ThirdCountrySoleTraderSubscriptionFlow,
+        VatRegisteredUkSubscriptionFlowPage,
+        3,
+        6,
+        VatDetailsSubscriptionFlowPage
+      ),
       (
         ThirdCountrySoleTraderSubscriptionFlow,
         VatDetailsSubscriptionFlowPage,
-        5,
-        7,
+        4,
+        6,
         ContactDetailsSubscriptionFlowPageGetEori
       ),
       (
         ThirdCountrySoleTraderSubscriptionFlow,
         ContactDetailsSubscriptionFlowPageGetEori,
+        5,
         6,
-        7,
         ContactAddressSubscriptionFlowPageGetEori
       ),
       (
         ThirdCountrySoleTraderSubscriptionFlow,
         ContactAddressSubscriptionFlowPageGetEori,
-        7,
-        7,
+        6,
+        6,
         ReviewDetailsPageGetYourEORI
       )
     )


### PR DESCRIPTION
Reverts hmrc/eori-common-component-registration-frontend#209 after discussions confirmed this should be part of the VAT edge case work. Confirmed with @RobertLaverick 