### PR TITLE
ECC-1571 fix for ampersand live issue

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/forms/models/AddressViewModel.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/forms/models/AddressViewModel.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.eoricommoncomponent.frontend.forms.models
 
 import play.api.libs.json.Json
-import play.twirl.api.utils.StringEscapeUtils
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.Address
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.AddressDetails
 
@@ -33,12 +32,7 @@ object AddressViewModel {
   val townCityMaxLength            = 35
 
   def apply(street: String, city: String, postcode: Option[String], countryCode: String): AddressViewModel =
-    new AddressViewModel(
-      StringEscapeUtils.escapeXml11(street.trim),
-      StringEscapeUtils.escapeXml11(city.trim),
-      postcode.map(_.trim),
-      countryCode
-    )
+    new AddressViewModel(street.trim, city.trim, postcode.map(_.trim), countryCode)
 
   def apply(sixLineAddress: Address): AddressViewModel = {
     val line1 = (sixLineAddress.addressLine1.trim.take(sixLineAddressLine1MaxLength) + " " + sixLineAddress.addressLine2
@@ -48,12 +42,7 @@ object AddressViewModel {
     val townCity    = sixLineAddress.addressLine3.getOrElse("").trim.take(townCityMaxLength)
     val postCode    = sixLineAddress.postalCode.map(_.trim)
     val countryCode = sixLineAddress.countryCode
-    AddressViewModel(
-      StringEscapeUtils.escapeXml11(line1),
-      StringEscapeUtils.escapeXml11(townCity),
-      postCode.map(StringEscapeUtils.escapeXml11(_)),
-      StringEscapeUtils.escapeXml11(countryCode)
-    )
+    AddressViewModel(line1, townCity, postCode, countryCode)
   }
 
 }

--- a/test/unit/forms/models/subscription/AddressViewModelSpec.scala
+++ b/test/unit/forms/models/subscription/AddressViewModelSpec.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.forms.models.AddressViewModel
 
 class AddressViewModelSpec extends UnitSpec {
 
-  val addressLine1 = "some building"
+  var addressLine1 = "some building"
   val addressLine2 = "some street"
   val addressLine3 = "some area"
   val addressLine4 = "some town"
@@ -51,6 +51,25 @@ class AddressViewModelSpec extends UnitSpec {
         countryCode
       )
       AddressViewModel(address) shouldEqual expectedAddress
+    }
+
+    "special characters not escaped in address" in {
+
+      val addressLine1WithSpecial = addressLine1 + " & co"
+
+      val address = Address(
+        addressLine1WithSpecial,
+        Some(addressLine2),
+        Some(addressLine3),
+        Some(addressLine4),
+        Some(postCode),
+        countryCode
+      )
+
+      val expectedAddressWithSpecial =
+        AddressViewModel(addressLine1WithSpecial + " " + addressLine2, addressLine3, Some(postCode), countryCode)
+
+      AddressViewModel(address) shouldEqual expectedAddressWithSpecial
     }
 
     "limit line 2 field to 35 chars" in {

--- a/test/unit/forms/models/subscription/AddressViewModelSpec.scala
+++ b/test/unit/forms/models/subscription/AddressViewModelSpec.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.forms.models.AddressViewModel
 
 class AddressViewModelSpec extends UnitSpec {
 
-  var addressLine1 = "some building"
+  val addressLine1 = "some building"
   val addressLine2 = "some street"
   val addressLine3 = "some area"
   val addressLine4 = "some town"


### PR DESCRIPTION
Original code was designed to protect the service against XSS in ECC-1440. We can safely remove the code in this change as we still have protection on input fields to prevent users running a script, like the one raised in the external pen test "<svg/onload=alert('field-name')>"