### PR TITLE
Revert "ECC-2019 use default CSP directives provided by play-bootstrap"

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -29,6 +29,26 @@ play.i18n.langs = ["en", "cy"]
 play.http.errorHandler = "uk.gov.hmrc.eoricommoncomponent.frontend.CdsErrorHandler"
 
 play.filters.enabled += play.filters.csp.CSPFilter
+#Google Analytics configuration based on https://developers.google.com/tag-platform/tag-manager/web/csp#google_analytics_4_google_analytics
+play.filters.csp {
+  nonce {
+    enabled = true
+    pattern = "%CSP_NONCE_PATTERN%"
+    header = true
+  }
+  directives {
+    base-uri = "'self'"
+    block-all-mixed-content = ""
+    child-src = "'self' https://*.googletagmanager.com"
+    connect-src = "'self' https://stats.g.doubleclick.net https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.g.doubleclick.net https://*.google.com"
+    default-src = "'none'"
+    font-src = "'self' https://ssl.gstatic.com https://www.gstatic.com https://fonts.gstatic.com https://fonts.googleapis.com"
+    frame-ancestors = "'self'"
+    img-src =  "'self' https://ssl.gstatic.com https://www.gstatic.com https://*.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com https://*.g.doubleclick.net https://*.google.com"
+    script-src = ${play.filters.csp.nonce.pattern} "'strict-dynamic' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' https://*.googletagmanager.com https://tagmanager.google.com https://*.google-analytics.com"
+    style-src = ${play.filters.csp.nonce.pattern} "'self' https://tagmanager.google.com https://fonts.googleapis.com"
+  }
+}
 
 # Router
 # ~~~~~


### PR DESCRIPTION
This reverts commit 4668e81c3793163fa9228660b9a14c79017bc491.