### PR TITLE
DDCYLS-6062

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -24,7 +24,6 @@ newlines.alwaysBeforeElseAfterCurlyIf = false
 
 rewrite.rules = [
   PreferCurlyFors
-  RedundantBraces,
   RedundantParens,
   SortImports
 ]

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/EmbassyAddressController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/EmbassyAddressController.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eoricommoncomponent.frontend.controllers
+
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.auth.AuthAction
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.CdsOrganisationType.EmbassyId
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.{EmbassyAddressMatchModel, LoggedInUserWithEnrolments}
+import uk.gov.hmrc.eoricommoncomponent.frontend.forms.embassy.EmbassyAddressForm
+import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.RegistrationDetailsService
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{RequestSessionData, SessionCache}
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.countries.Countries
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.mapping.RegistrationDetailsCreator
+import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.embassy_address
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class EmbassyAddressController @Inject() (
+  authAction: AuthAction,
+  sessionCache: SessionCache,
+  requestSessionData: RequestSessionData,
+  mcc: MessagesControllerComponents,
+  regDetailsCreator: RegistrationDetailsCreator,
+  registrationDetailsService: RegistrationDetailsService,
+  subscriptionFlowManager: SubscriptionFlowManager,
+  embassyAddressForm: EmbassyAddressForm,
+  embassy_address_view: embassy_address
+)(implicit ec: ExecutionContext)
+    extends CdsController(mcc) {
+
+  def showForm(isInReviewMode: Boolean = false, service: Service): Action[AnyContent] =
+    authAction.enrolledUserWithSessionAction(service) { implicit request => _: LoggedInUserWithEnrolments =>
+      sessionCache.registrationDetails.map { regDetails =>
+        val addr = regDetails.address
+        val embassyAddrModel = EmbassyAddressMatchModel(
+          addr.addressLine1,
+          addr.addressLine2,
+          addr.addressLine3.getOrElse(""),
+          addr.postalCode.getOrElse(""),
+          addr.countryCode
+        )
+        val filledForm = embassyAddressForm.form.fill(embassyAddrModel)
+        val (countriesToInclude, countriesInCountryPicker) =
+          Countries.getCountryParameters(requestSessionData.selectedUserLocationWithIslands)
+        Ok(
+          embassy_address_view(
+            isInReviewMode,
+            filledForm,
+            countriesToInclude,
+            countriesInCountryPicker,
+            EmbassyId,
+            service
+          )
+        )
+      }
+    }
+
+  def submit(isInReviewMode: Boolean = false, service: Service): Action[AnyContent] =
+    authAction.enrolledUserWithSessionAction(service) { implicit request => _: LoggedInUserWithEnrolments =>
+      val filledForm = embassyAddressForm.form.bindFromRequest()
+
+      val (countriesToInclude, countriesInCountryPicker) =
+        Countries.getCountryParameters(requestSessionData.selectedUserLocationWithIslands)
+
+      if (filledForm.hasErrors)
+        Future.successful(
+          BadRequest(
+            embassy_address_view(
+              isInReviewMode,
+              filledForm,
+              countriesToInclude,
+              countriesInCountryPicker,
+              EmbassyId,
+              service
+            )
+          )
+        )
+      else if (isInReviewMode)
+        registrationDetailsService
+          .cacheAddress(regDetailsCreator.registrationAddressEmbassyAddress(filledForm.value.head))
+          .map(_ => Redirect(routes.DetermineReviewPageController.determineRoute(service)))
+      else
+        registrationDetailsService.cacheAddress(
+          regDetailsCreator.registrationAddressEmbassyAddress(filledForm.value.head)
+        ).flatMap {
+          _ =>
+            subscriptionFlowManager.startSubscriptionFlow(service)
+        } map {
+          case (firstSubscriptionPage, session) => Redirect(firstSubscriptionPage.url(service)).withSession(session)
+        }
+    }
+
+}

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/EmbassyNameController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/EmbassyNameController.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eoricommoncomponent.frontend.controllers
+
+import play.api.data.Form
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.auth.AuthAction
+import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes.{
+  DetermineReviewPageController,
+  EmbassyAddressController
+}
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.LoggedInUserWithEnrolments
+import uk.gov.hmrc.eoricommoncomponent.frontend.forms.embassy.EmbassyNameForm
+import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.SubscriptionDetailsService
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.RequestSessionData
+import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.what_is_your_embassy_name
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class EmbassyNameController @Inject() (
+  authAction: AuthAction,
+  mcc: MessagesControllerComponents,
+  embassyNameForm: EmbassyNameForm,
+  whatIsYourEmbassyNameView: what_is_your_embassy_name,
+  subscriptionDetailsService: SubscriptionDetailsService,
+  requestSessionData: RequestSessionData
+)(implicit ec: ExecutionContext)
+    extends CdsController(mcc) {
+
+  val form: Form[String] = embassyNameForm.embassyNameForm()
+
+  def showForm(isInReviewMode: Boolean = false, organisationType: String, service: Service): Action[AnyContent] =
+    authAction.enrolledUserWithSessionAction(service) { implicit request => _: LoggedInUserWithEnrolments =>
+      subscriptionDetailsService.cachedEmbassyName.flatMap { optEmbassyName =>
+        val updatedForm = optEmbassyName.fold(form)(form.fill)
+        Future.successful(Ok(whatIsYourEmbassyNameView(isInReviewMode, updatedForm, organisationType, service)))
+      }
+    }
+
+  def submit(isInReviewMode: Boolean = false, organisationType: String, service: Service): Action[AnyContent] =
+    authAction.enrolledUserWithSessionAction(service) { implicit request => _: LoggedInUserWithEnrolments =>
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(
+            BadRequest(whatIsYourEmbassyNameView(isInReviewMode, formWithErrors, organisationType, service))
+          ),
+        embassyNameFormData =>
+          subscriptionDetailsService.cacheEmbassyName(embassyNameFormData).flatMap { _ =>
+            if (!isInReviewMode)
+              subscriptionDetailsService.updateSubscriptionDetailsEmbassyName(embassyNameFormData).map(
+                _ => Redirect(EmbassyAddressController.showForm(isInReviewMode = false, service))
+              )
+            else
+              Future.successful(Redirect(DetermineReviewPageController.determineRoute(service)))
+          }
+      )
+    }
+
+}

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/OrganisationTypeController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/OrganisationTypeController.scala
@@ -54,6 +54,9 @@ class OrganisationTypeController @Inject() (
   private def organisationWhatIsYourOrgName(orgType: String, service: Service): Call =
     WhatIsYourOrgNameController.showForm(isInReviewMode = false, orgType, service)
 
+  def embassyMatching(orgType: String, service: Service): Call =
+    EmbassyNameController.showForm(isInReviewMode = false, orgType, service)
+
   private def matchingDestinations(service: Service): Map[CdsOrganisationType, Call] =
     Map[CdsOrganisationType, Call](
       Company                       -> nameIdOrganisationMatching(CompanyId, service),
@@ -64,7 +67,8 @@ class OrganisationTypeController @Inject() (
       CharityPublicBodyNotForProfit -> nameIdOrganisationMatching(CharityPublicBodyNotForProfitId, service),
       ThirdCountryOrganisation      -> organisationWhatIsYourOrgName(ThirdCountryOrganisationId, service),
       ThirdCountrySoleTrader        -> thirdCountryIndividualMatching(ThirdCountrySoleTraderId, service),
-      ThirdCountryIndividual        -> thirdCountryIndividualMatching(ThirdCountryIndividualId, service)
+      ThirdCountryIndividual        -> thirdCountryIndividualMatching(ThirdCountryIndividualId, service),
+      Embassy                       -> embassyMatching(EmbassyId, service)
     )
 
   def form(service: Service): Action[AnyContent] =

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/SubscriptionFlowManager.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/SubscriptionFlowManager.scala
@@ -128,6 +128,8 @@ class SubscriptionFlowManager @Inject() (requestSessionData: RequestSessionData,
           SubscriptionFlow(OrganisationSubscriptionFlow.name)
         case _: RegistrationDetailsIndividual =>
           SubscriptionFlow(IndividualSubscriptionFlow.name)
+        case _: RegistrationDetailsEmbassy =>
+          SubscriptionFlow(EmbassySubscriptionFlow.name)
         case _ => throw DataUnavailableException("Incomplete cache cannot complete journey")
       }
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/WhatIsYourContactAddressController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/WhatIsYourContactAddressController.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eoricommoncomponent.frontend.controllers
+
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.auth.AuthAction
+import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes.ContactAddressController
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.CdsOrganisationType.EmbassyId
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.LoggedInUserWithEnrolments
+import uk.gov.hmrc.eoricommoncomponent.frontend.forms.MatchingForms.contactAddressForm
+import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.SubscriptionDetailsService
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.RequestSessionData
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.countries.Countries
+import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.what_is_your_contact_address
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class WhatIsYourContactAddressController @Inject() (
+  authAction: AuthAction,
+  mcc: MessagesControllerComponents,
+  requestSessionData: RequestSessionData,
+  subscriptionDetailsService: SubscriptionDetailsService,
+  what_is_your_contact_address_view: what_is_your_contact_address
+)(implicit executionContext: ExecutionContext)
+    extends CdsController(mcc) {
+
+  def showForm(isInReviewMode: Boolean = false, service: Service): Action[AnyContent] = {
+    authAction.enrolledUserWithSessionAction(service) { implicit request => _: LoggedInUserWithEnrolments =>
+      val (countriesToInclude, countriesInCountryPicker) =
+        Countries.getCountryParameters(requestSessionData.selectedUserLocationWithIslands)
+
+      Future.successful(
+        Ok(
+          what_is_your_contact_address_view(
+            isInReviewMode,
+            contactAddressForm,
+            countriesToInclude,
+            countriesInCountryPicker,
+            EmbassyId,
+            service
+          )
+        )
+      )
+    }
+  }
+
+  def submit(isInReviewMode: Boolean = false, service: Service): Action[AnyContent] = {
+    authAction.enrolledUserWithSessionAction(service) { implicit request => _: LoggedInUserWithEnrolments =>
+      val filledForm = contactAddressForm.bindFromRequest()
+
+      val (countriesToInclude, countriesInCountryPicker) =
+        Countries.getCountryParameters(requestSessionData.selectedUserLocationWithIslands)
+
+      if (filledForm.hasErrors)
+        Future.successful(
+          BadRequest(
+            what_is_your_contact_address_view(
+              isInReviewMode,
+              filledForm,
+              countriesToInclude,
+              countriesInCountryPicker,
+              EmbassyId,
+              service
+            )
+          )
+        )
+      else {
+        for {
+          _ <- subscriptionDetailsService.cacheAddressDetails(filledForm.value.head)
+        } yield Redirect(ContactAddressController.submit(isInReviewMode, service))
+      }
+    }
+  }
+
+}

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/CdsOrganisationType.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/CdsOrganisationType.scala
@@ -30,6 +30,7 @@ object CdsOrganisationType {
   val PartnershipId                   = "partnership"
   val LimitedLiabilityPartnershipId   = "limited-liability-partnership"
   val CharityPublicBodyNotForProfitId = "charity-public-body-not-for-profit"
+  val EmbassyId                       = "embassy"
 
   val EUOrganisationId = "eu-organisation"
   val EUIndividualId   = "eu-individual"
@@ -44,6 +45,7 @@ object CdsOrganisationType {
   val Partnership: CdsOrganisationType                   = CdsOrganisationType(PartnershipId)
   val LimitedLiabilityPartnership: CdsOrganisationType   = CdsOrganisationType(LimitedLiabilityPartnershipId)
   val CharityPublicBodyNotForProfit: CdsOrganisationType = CdsOrganisationType(CharityPublicBodyNotForProfitId)
+  val Embassy: CdsOrganisationType                       = CdsOrganisationType(EmbassyId)
 
   val EUOrganisation: CdsOrganisationType = CdsOrganisationType(EUOrganisationId)
   val EUIndividual: CdsOrganisationType   = CdsOrganisationType(EUIndividualId)
@@ -63,7 +65,8 @@ object CdsOrganisationType {
     EUIndividualId                  -> EUIndividual,
     ThirdCountryOrganisationId      -> ThirdCountryOrganisation,
     ThirdCountrySoleTraderId        -> ThirdCountrySoleTrader,
-    ThirdCountryIndividualId        -> ThirdCountryIndividual
+    ThirdCountryIndividualId        -> ThirdCountryIndividual,
+    EmbassyId                       -> Embassy
   )
 
   val IndividualOrganisations: Seq[CdsOrganisationType] =

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/matchingModels.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/matchingModels.scala
@@ -271,6 +271,22 @@ object SixLineAddressMatchModel {
 
 }
 
+case class EmbassyAddressMatchModel(
+  lineOne: String,
+  lineTwo: Option[String],
+  townCity: String,
+  postcode: String,
+  country: String
+)
+
+case class ContactAddressMatchModel(
+  lineOne: String,
+  lineTwo: Option[String],
+  townCity: String,
+  postcode: String,
+  country: String
+)
+
 case class IndividualNameAndDateOfBirth(firstName: String, lastName: String, dateOfBirth: LocalDate)
     extends IndividualName
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/registrationDetailsModels.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/registrationDetailsModels.scala
@@ -16,10 +16,13 @@
 
 package uk.gov.hmrc.eoricommoncomponent.frontend.domain
 
+import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.CdsOrganisationType.EmbassyId
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.RegistrationDetailsEmbassy.{embassyReads, embassyWrites}
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.Address
 
-import java.time.LocalDate
+import java.time.{Instant, LocalDate}
 
 case class BusinessAddress(
   line_1: String,
@@ -47,6 +50,7 @@ sealed trait RegistrationDetails {
 
   def dateOfEstablishmentOption: Option[LocalDate] = None
   def dateOfBirthOption: Option[LocalDate]         = None
+  def orgType: Option[String]                      = None
 }
 
 case class RegistrationDetailsOrganisation(
@@ -71,6 +75,15 @@ case class RegistrationDetailsIndividual(
 ) extends RegistrationDetails {
   override def dateOfBirthOption: Option[LocalDate] = Some(dateOfBirth)
 }
+
+case class RegistrationDetailsEmbassy(
+  customsId: Option[CustomsId] = None,
+  sapNumber: TaxPayerId = TaxPayerId(""),
+  safeId: SafeId = SafeId(""),
+  name: String,
+  address: Address = Address("", None, None, None, None, ""),
+  override val orgType: Option[String] = Some(EmbassyId)
+) extends RegistrationDetails
 
 case class RegistrationDetailsSafeId(
   safeId: SafeId,
@@ -118,14 +131,22 @@ object RegistrationDetails {
   private val individualFormat: OFormat[RegistrationDetailsIndividual]     = Json.format[RegistrationDetailsIndividual]
   private val registrationSafeIdFormat: OFormat[RegistrationDetailsSafeId] = Json.format[RegistrationDetailsSafeId]
 
+  /**
+    * TODO in the future change this to always read the orgType & create the corresponding registration details
+    * object based on it.
+    */
   implicit val formats: Format[RegistrationDetails] = Format[RegistrationDetails](
     Reads { js =>
       individualFormat.reads(js) match {
         case ok: JsSuccess[RegistrationDetailsIndividual] => ok
         case _ =>
-          orgFormat.reads(js) match {
-            case ok: JsSuccess[RegistrationDetailsOrganisation] => ok
-            case _                                              => registrationSafeIdFormat.reads(js)
+          embassyReads.reads(js) match {
+            case ok: JsSuccess[RegistrationDetailsEmbassy] => ok
+            case _ =>
+              orgFormat.reads(js) match {
+                case ok: JsSuccess[RegistrationDetailsOrganisation] => ok
+                case _                                              => registrationSafeIdFormat.reads(js)
+              }
           }
       }
     },
@@ -133,6 +154,7 @@ object RegistrationDetails {
       case individual: RegistrationDetailsIndividual     => individualFormat.writes(individual)
       case organisation: RegistrationDetailsOrganisation => orgFormat.writes(organisation)
       case regSafeId: RegistrationDetailsSafeId          => registrationSafeIdFormat.writes(regSafeId)
+      case embassy: RegistrationDetailsEmbassy           => embassyWrites.writes(embassy)
     }
   )
 
@@ -174,5 +196,65 @@ object RegistrationDetailsOrganisation {
       None,
       None
     )
+
+}
+
+object RegistrationDetailsEmbassy {
+
+  def apply(embassyName: String): RegistrationDetailsEmbassy = {
+    new RegistrationDetailsEmbassy(name = embassyName)
+  }
+
+  def apply(
+    embassyName: String,
+    embassyAddress: Address,
+    embassyCustomsId: Option[CustomsId],
+    embassySafeId: SafeId
+  ): RegistrationDetailsEmbassy = {
+    new RegistrationDetailsEmbassy(
+      name = embassyName,
+      address = embassyAddress,
+      customsId = embassyCustomsId,
+      safeId = embassySafeId
+    )
+  }
+
+  def initEmpty(): RegistrationDetailsEmbassy = {
+    new RegistrationDetailsEmbassy(name = "")
+  }
+
+  val embassyWrites: Writes[RegistrationDetailsEmbassy] = (o: RegistrationDetailsEmbassy) => {
+    JsObject(
+      Seq(
+        "orgType"   -> JsString(o.orgType.head),
+        "name"      -> JsString(o.name),
+        "address"   -> Json.toJson(o.address),
+        "customsId" -> Json.toJson(o.customsId),
+        "safeId"    -> Json.toJson(o.safeId)
+        // TODO date of establishment
+      )
+    )
+  }
+
+  private val blindReads: Reads[RegistrationDetailsEmbassy] = (
+    (__ \ "orgType").read[String] and
+      (__ \ "name").read[String] and
+      (__ \ "address").read[Address] and
+      (__ \ "customsId").readNullable[CustomsId] and
+      (__ \ "safeId").read[SafeId]
+  )((_, name, address, customsId, safeId) => RegistrationDetailsEmbassy(name, address, customsId, safeId))
+
+  val embassyReads: Reads[RegistrationDetailsEmbassy] = (json: JsValue) => {
+    val value = (json \ "orgType").validateOpt[String]
+
+    if (value.get.isEmpty) {
+      JsError("Unable to read json as RegistrationDetailsEmbassy")
+    } else {
+      value.map {
+        case Some(orgType) if orgType == EmbassyId => blindReads.reads(json).get
+      }
+    }
+
+  }
 
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/subscription/SubscriptionDetails.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/subscription/SubscriptionDetails.scala
@@ -17,6 +17,8 @@
 package uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription
 
 import play.api.Logging
+import play.api.libs.json._
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
 import play.api.libs.json.{Format, Json}
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
 import uk.gov.hmrc.eoricommoncomponent.frontend.forms.models.{
@@ -50,7 +52,8 @@ case class SubscriptionDetails(
   customsId: Option[CustomsId] = None,
   formData: FormData = FormData(),
   registeredCompany: Option[CompanyRegisteredCountry] = None,
-  postCodeForValidation: Option[String] = None
+  postCodeForValidation: Option[String] = None,
+  embassyName: Option[String] = None
 ) extends Logging {
 
   def name: Option[String] = {
@@ -59,13 +62,151 @@ case class SubscriptionDetails(
     val dobDetailsName   = nameDobDetails.map(_.name)
     val nameDetailsName  = nameDetails.map(_.name)
 
-    idOrgDetailsName orElse orgDetailsName orElse dobDetailsName orElse nameDetailsName
+    idOrgDetailsName orElse orgDetailsName orElse dobDetailsName orElse nameDetailsName orElse embassyName
   }
 
 }
 
 object SubscriptionDetails {
-  implicit val format: Format[SubscriptionDetails] = Json.format[SubscriptionDetails]
+
+  private type FirstTwenty =
+    (
+      Option[BusinessShortName],
+      Option[LocalDate],
+      Option[Boolean],
+      Option[VatDetails],
+      Option[VatControlListResponse],
+      Option[Boolean],
+      Option[Boolean],
+      Option[ContactDetailsModel],
+      Option[String],
+      Option[String],
+      Option[ExistingEori],
+      Option[String],
+      Option[AddressViewModel],
+      Option[NameIdOrganisationMatchModel],
+      Option[NameOrganisationMatchModel],
+      Option[NameDobMatchModel],
+      Option[NameMatchModel],
+      Option[IdMatchModel],
+      Option[CustomsId],
+      FormData,
+      Option[CompanyRegisteredCountry]
+    )
+
+  private type LastTwo = (Option[String], Option[String])
+
+  implicit val firstTwenty: OFormat[FirstTwenty] =
+    ((__ \ "businessShortName").formatNullable[BusinessShortName]
+      ~ (__ \ "dateEstablished").formatNullable[LocalDate]
+      ~ (__ \ "vatRegisteredUk").formatNullable[Boolean]
+      ~ (__ \ "ukVatDetails").formatNullable[VatDetails]
+      ~ (__ \ "vatControlListResponse").formatNullable[VatControlListResponse]
+      ~ (__ \ "vatVerificationOption").formatNullable[Boolean]
+      ~ (__ \ "personalDataDisclosureConsent").formatNullable[Boolean]
+      ~ (__ \ "contactDetails").formatNullable[ContactDetailsModel]
+      ~ (__ \ "sicCode").formatNullable[String]
+      ~ (__ \ "eoriNumber").formatNullable[String]
+      ~ (__ \ "existingEoriNumber").formatNullable[ExistingEori]
+      ~ (__ \ "email").formatNullable[String]
+      ~ (__ \ "addressDetails").formatNullable[AddressViewModel]
+      ~ (__ \ "nameIdOrganisationDetails").formatNullable[NameIdOrganisationMatchModel]
+      ~ (__ \ "nameOrganisationDetails").formatNullable[NameOrganisationMatchModel]
+      ~ (__ \ "nameDobDetails").formatNullable[NameDobMatchModel]
+      ~ (__ \ "nameDetails").formatNullable[NameMatchModel]
+      ~ (__ \ "idDetails").formatNullable[IdMatchModel]
+      ~ (__ \ "customsId").formatNullable[CustomsId]
+      ~ (__ \ "formData").format[FormData]
+      ~ (__ \ "registeredCompany").formatNullable[CompanyRegisteredCountry]).tupled
+
+  implicit val lastTwo: OFormat[LastTwo] =
+    ((__ \ "postCodeForValidation").formatNullable[String]
+      ~ (__ \ "embassyName").formatNullable[String]).tupled
+
+  implicit val subscriptionDetailsFormat: OFormat[SubscriptionDetails] =
+    (firstTwenty ~ lastTwo)(
+      {
+        case (
+              (
+                businessShortName,
+                dateEstablished,
+                vatRegisteredUk,
+                ukVatDetails,
+                vatControlListResponse,
+                vatVerificationOption,
+                personalDataDisclosureConsent,
+                contactDetails,
+                sicCode,
+                eoriNumber,
+                existingEoriNumber,
+                email,
+                addressDetails,
+                nameIdOrganisationDetails,
+                nameOrganisationDetails,
+                nameDobDetails,
+                nameDetails,
+                idDetails,
+                customsId,
+                formData,
+                registeredCompany
+              ),
+              (postCodeForValidation, embassyName)
+            ) =>
+          SubscriptionDetails(
+            businessShortName = businessShortName,
+            dateEstablished = dateEstablished,
+            vatRegisteredUk = vatRegisteredUk,
+            ukVatDetails = ukVatDetails,
+            vatControlListResponse = vatControlListResponse,
+            vatVerificationOption = vatVerificationOption,
+            personalDataDisclosureConsent = personalDataDisclosureConsent,
+            contactDetails = contactDetails,
+            sicCode = sicCode,
+            eoriNumber = eoriNumber,
+            existingEoriNumber = existingEoriNumber,
+            email = email,
+            addressDetails = addressDetails,
+            nameIdOrganisationDetails = nameIdOrganisationDetails,
+            nameOrganisationDetails = nameOrganisationDetails,
+            nameDobDetails = nameDobDetails,
+            nameDetails = nameDetails,
+            idDetails = idDetails,
+            customsId = customsId,
+            formData = formData,
+            registeredCompany = registeredCompany,
+            postCodeForValidation = postCodeForValidation,
+            embassyName = embassyName
+          )
+      }: (FirstTwenty, LastTwo) => SubscriptionDetails,
+      (subscriptionDetails: SubscriptionDetails) =>
+        (
+          (
+            subscriptionDetails.businessShortName,
+            subscriptionDetails.dateEstablished,
+            subscriptionDetails.vatRegisteredUk,
+            subscriptionDetails.ukVatDetails,
+            subscriptionDetails.vatControlListResponse,
+            subscriptionDetails.vatVerificationOption,
+            subscriptionDetails.personalDataDisclosureConsent,
+            subscriptionDetails.contactDetails,
+            subscriptionDetails.sicCode,
+            subscriptionDetails.eoriNumber,
+            subscriptionDetails.existingEoriNumber,
+            subscriptionDetails.email,
+            subscriptionDetails.addressDetails,
+            subscriptionDetails.nameIdOrganisationDetails,
+            subscriptionDetails.nameOrganisationDetails,
+            subscriptionDetails.nameDobDetails,
+            subscriptionDetails.nameDetails,
+            subscriptionDetails.idDetails,
+            subscriptionDetails.customsId,
+            subscriptionDetails.formData,
+            subscriptionDetails.registeredCompany
+          ),
+          (subscriptionDetails.postCodeForValidation, subscriptionDetails.embassyName)
+        )
+    )
+
 }
 
 case class FormData(

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/subscription/SubscriptionFlow.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/subscription/SubscriptionFlow.scala
@@ -99,9 +99,18 @@ object SubscriptionFlows {
     )
   )
 
+  private val embassyFlowConfig = createFlowConfig(
+    List(
+      EoriConsentSubscriptionFlowPage,
+      ContactDetailsSubscriptionFlowPageGetEori,
+      ContactAddressSubscriptionFlowPageGetEori
+    )
+  )
+
   val flows: Map[SubscriptionFlow, SubscriptionFlowConfig] = Map(
     OrganisationSubscriptionFlow             -> corporateFlowConfig,
     PartnershipSubscriptionFlow              -> partnershipFlowConfig,
+    EmbassySubscriptionFlow                  -> embassyFlowConfig,
     SoleTraderSubscriptionFlow               -> soleTraderFlowConfig,
     IndividualSubscriptionFlow               -> individualFlowConfig,
     ThirdCountryOrganisationSubscriptionFlow -> thirdCountryCorporateFlowConfig,
@@ -124,6 +133,8 @@ case class SubscriptionFlowInfo(stepNumber: Int, totalSteps: Int, nextPage: Subs
 sealed abstract class SubscriptionFlow(val name: String, val isIndividualFlow: Boolean)
 
 case object OrganisationSubscriptionFlow extends SubscriptionFlow("Organisation", isIndividualFlow = false)
+
+case object EmbassySubscriptionFlow extends SubscriptionFlow("Embassy", isIndividualFlow = false)
 
 case object PartnershipSubscriptionFlow extends SubscriptionFlow("Partnership", isIndividualFlow = false)
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/forms/MatchingForms.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/forms/MatchingForms.scala
@@ -441,4 +441,16 @@ object MatchingForms extends Mappings with Logging {
     )
   )
 
+  def contactAddressForm: Form[ContactAddressMatchModel] = {
+    Form(
+      mapping(
+        "line-1"      -> text.verifying(validLine1),
+        "line-2"      -> optional(text.verifying(validLine2)),
+        "townCity"    -> text.verifying(validLine3),
+        "postcode"    -> mandatoryPostCodeMapping,
+        "countryCode" -> default(text, countryCodeGB)
+      )(ContactAddressMatchModel.apply)(ContactAddressMatchModel.unapply)
+    )
+  }
+
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/forms/embassy/EmbassyAddressForm.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/forms/embassy/EmbassyAddressForm.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eoricommoncomponent.frontend.forms.embassy
+
+import play.api.data.Form
+import play.api.data.Forms.{default, mapping, optional, text}
+import play.api.data.validation.{Constraint, Invalid, Valid, ValidationError}
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.EmbassyAddressMatchModel
+import uk.gov.hmrc.eoricommoncomponent.frontend.forms.FormValidation.mandatoryPostCodeMapping
+import uk.gov.hmrc.eoricommoncomponent.frontend.forms.MatchingForms.countryCodeGB
+
+class EmbassyAddressForm() {
+
+  private val noTagsRegex = "^[^<>]+$"
+
+  def form: Form[EmbassyAddressMatchModel] =
+    Form {
+      mapping(
+        "line-1"      -> text.verifying(validLine1),
+        "line-2"      -> optional(text.verifying(validLine2)),
+        "townCity"    -> text.verifying(validLineTownCity),
+        "postcode"    -> mandatoryPostCodeMapping,
+        "countryCode" -> default(text, countryCodeGB)
+      )(EmbassyAddressMatchModel.apply)(EmbassyAddressMatchModel.unapply)
+    }
+
+  private def validLine1: Constraint[String] =
+    Constraint({
+      case s if s.trim.isEmpty => Invalid(ValidationError("cds.matching.embassy-address.line-1.error.empty"))
+      case s if !s.matches(noTagsRegex) =>
+        Invalid(ValidationError("cds.matching.embassy-address.line.error.invalid-chars"))
+      case _ => Valid
+    })
+
+  private def validLine2: Constraint[String] =
+    Constraint({
+      case s if !s.matches(noTagsRegex) =>
+        Invalid(ValidationError("cds.matching.embassy-address.line.error.invalid-chars"))
+      case _ => Valid
+    })
+
+  private def validLineTownCity: Constraint[String] =
+    Constraint({
+      case s if s.trim.isEmpty => Invalid(ValidationError("cds.matching.embassy-address.town-city.error.empty"))
+      case s if s.trim.length > 34 =>
+        Invalid(ValidationError("cds.matching.embassy-address.town-city.error.too-long"))
+      case s if !s.matches(noTagsRegex) =>
+        Invalid(ValidationError("cds.matching.embassy-address.line.error.invalid-chars"))
+      case _ => Valid
+    })
+
+}

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/forms/embassy/EmbassyNameForm.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/forms/embassy/EmbassyNameForm.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eoricommoncomponent.frontend.forms.embassy
+
+import play.api.data.Form
+import play.api.data.Forms.{mapping, text}
+import play.api.data.validation.{Constraint, Invalid, Valid, ValidationError}
+import uk.gov.hmrc.eoricommoncomponent.frontend.forms.models.mappings.Mappings
+
+class EmbassyNameForm() extends Mappings {
+
+  private val noTagsRegex = "^[^<>]+$"
+
+  def embassyNameForm(): Form[String] = Form(
+    mapping("name" -> text.verifying(validEmbassyName))(name => name)(name => Some(name))
+  )
+
+  private def validEmbassyName: Constraint[String] =
+    Constraint({
+      case s if s.isEmpty => Invalid(ValidationError("cds.matching.embassy-name.error.name"))
+      case s if !s.matches(noTagsRegex) =>
+        Invalid(ValidationError("cds.matching-error.business-details.embassy-name.invalid-char"))
+      case _ => Valid
+    })
+
+}

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/models/Service.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/models/Service.scala
@@ -38,6 +38,18 @@ object Service {
   val regimeCDS         = "CDS"
   val eoriOnly: Service = Service("eori-only", "HMRC-CUS-ORG", "", None, "", "", None)
 
+  val goodsVehiclMovementCode = "gagmr"
+
+  val gagmr: Service = Service(
+    goodsVehiclMovementCode,
+    "HMRC-GVMS-ORG",
+    "GaGMR",
+    None,
+    "the Goods Vehicle Movement Service",
+    "y Gwasanaeth Symud Cerbydau Nwyddau",
+    None
+  )
+
   private val supportedServicesMap: Map[String, Service] = new ServiceConfig(
     Configuration(ConfigFactory.load())
   ).supportedServicesMap

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/RegistrationDetailsService.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/RegistrationDetailsService.scala
@@ -23,6 +23,7 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.Address
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.{FormData, SubscriptionDetails}
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.{
   CdsOrganisationType,
+  RegistrationDetailsEmbassy,
   RegistrationDetailsIndividual,
   RegistrationDetailsOrganisation
 }
@@ -38,6 +39,7 @@ class RegistrationDetailsService @Inject() (sessionCache: SessionCache)(implicit
     sessionCache.registrationDetails.map {
       case rdo: RegistrationDetailsOrganisation => rdo.copy(address = address)
       case rdi: RegistrationDetailsIndividual   => rdi.copy(address = address)
+      case rde: RegistrationDetailsEmbassy      => rde.copy(address = address)
       case _ =>
         val error = "Incomplete cache cannot complete journey"
         // $COVERAGE-OFF$Loggers
@@ -48,13 +50,16 @@ class RegistrationDetailsService @Inject() (sessionCache: SessionCache)(implicit
 
   def initialiseCacheWithRegistrationDetails(
     organisationType: CdsOrganisationType
-  )(implicit request: Request[_]): Future[Boolean] =
+  )(implicit request: Request[_]): Future[Boolean] = {
     sessionCache.saveSubscriptionDetails(
       SubscriptionDetails(formData = FormData(organisationType = Some(organisationType)))
     ).flatMap(_ => saveRegistrationDetails(organisationType))
+  }
 
-  private def saveRegistrationDetails(orgType: CdsOrganisationType)(implicit request: Request[_]) =
+  private def saveRegistrationDetails(orgType: CdsOrganisationType)(implicit request: Request[_]): Future[Boolean] = {
     if (IndividualOrganisations.contains(orgType)) sessionCache.saveRegistrationDetails(RegistrationDetailsIndividual())
+    else if (Embassy == orgType) sessionCache.saveRegistrationDetails(RegistrationDetailsEmbassy.initEmpty())
     else sessionCache.saveRegistrationDetails(RegistrationDetailsOrganisation())
+  }
 
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/SubscriptionDetailsService.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/SubscriptionDetailsService.scala
@@ -50,10 +50,10 @@ class SubscriptionDetailsService @Inject() (
 
   def saveSubscriptionDetails(
     insertNewDetails: SubscriptionDetails => SubscriptionDetails
-  )(implicit request: Request[_]): Future[Unit] = sessionCache.subscriptionDetails flatMap {
-    subDetails =>
+  )(implicit request: Request[_]): Future[Unit] =
+    sessionCache.subscriptionDetails flatMap { subDetails =>
       sessionCache.saveSubscriptionDetails(insertNewDetails(subDetails)).map(_ => ())
-  }
+    }
 
   def cacheContactDetails(contactDetailsModel: ContactDetailsModel, isInReviewMode: Boolean = false)(implicit
     request: Request[_]
@@ -86,10 +86,30 @@ class SubscriptionDetailsService @Inject() (
     )
   }
 
+  def cacheAddressDetails(address: ContactAddressMatchModel)(implicit request: Request[_]): Future[Unit] = {
+    saveSubscriptionDetails(
+      sd =>
+        sd.copy(contactDetails =
+          sd.contactDetails.map(
+            cdm =>
+              cdm.copy(
+                street = Some(s"${address.lineOne} ${address.lineTwo.getOrElse("")}"),
+                city = Some(s"${address.townCity}"),
+                postcode = Some(s"${address.postcode}"),
+                countryCode = Some(s"${address.country}")
+              )
+          )
+        )
+    )
+  }
+
   def cacheNameDetails(
     nameOrganisationMatchModel: NameOrganisationMatchModel
   )(implicit request: Request[_]): Future[Unit] =
     saveSubscriptionDetails(sd => sd.copy(nameOrganisationDetails = Some(nameOrganisationMatchModel)))
+
+  def cacheEmbassyName(embassyName: String)(implicit request: Request[_]): Future[Unit] =
+    saveSubscriptionDetails(sd => sd.copy(embassyName = Some(embassyName)))
 
   def cachedNameDetails(implicit request: Request[_]): Future[Option[NameOrganisationMatchModel]] =
     sessionCache.subscriptionDetails map (_.nameOrganisationDetails)
@@ -145,7 +165,7 @@ class SubscriptionDetailsService @Inject() (
   )(implicit request: Request[_]): Future[Unit] =
     saveSubscriptionDetails(sd => sd.copy(vatControlListResponse = Some(vatControlListResponse)))
 
-  def cacheVatRegisteredUk(yesNoAnswer: YesNo)(implicit request: Request[_]) =
+  def cacheVatRegisteredUk(yesNoAnswer: YesNo)(implicit request: Request[_]): Future[Unit] =
     saveSubscriptionDetails(sd => sd.copy(vatRegisteredUk = Some(yesNoAnswer.isYes)))
 
   def cacheConsentToDisclosePersonalDetails(yesNoAnswer: YesNo)(implicit request: Request[_]): Future[Unit] =
@@ -163,7 +183,10 @@ class SubscriptionDetailsService @Inject() (
   def cachedCustomsId(implicit request: Request[_]): Future[Option[CustomsId]] =
     sessionCache.subscriptionDetails map (_.customsId)
 
-  private def updateSubscriptionDetails(implicit request: Request[_]) =
+  def cachedEmbassyName(implicit request: Request[_]): Future[Option[String]] =
+    sessionCache.subscriptionDetails map (_.embassyName)
+
+  private def updateSubscriptionDetails(implicit request: Request[_]): Future[Unit] =
     for {
       subDetails <- sessionCache.subscriptionDetails
       _          <- sessionCache.saveSub01Outcome(Sub01Outcome(""))
@@ -171,7 +194,8 @@ class SubscriptionDetailsService @Inject() (
         SubscriptionDetails(
           nameOrganisationDetails = subDetails.nameOrganisationDetails,
           nameDobDetails = subDetails.nameDobDetails,
-          formData = subDetails.formData
+          formData = subDetails.formData,
+          embassyName = subDetails.embassyName
         )
       )
     } yield ()
@@ -185,6 +209,12 @@ class SubscriptionDetailsService @Inject() (
   def updateSubscriptionDetailsIndividual(implicit request: Request[_]): Future[Unit] =
     for {
       _ <- sessionCache.saveRegistrationDetails(RegistrationDetailsIndividual())
+      _ <- updateSubscriptionDetails
+    } yield ()
+
+  def updateSubscriptionDetailsEmbassyName(embassyName: String)(implicit request: Request[_]): Future[Unit] =
+    for {
+      _ <- sessionCache.saveRegistrationDetails(RegistrationDetailsEmbassy(embassyName))
       _ <- updateSubscriptionDetails
     } yield ()
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/mapping/RegistrationDetailsCreator.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/mapping/RegistrationDetailsCreator.scala
@@ -150,6 +150,16 @@ class RegistrationDetailsCreator {
       orgAddress.country
     )
 
+  def registrationAddressEmbassyAddress(embassyAddress: EmbassyAddressMatchModel): Address =
+    Address(
+      embassyAddress.lineOne,
+      embassyAddress.lineTwo,
+      Some(embassyAddress.townCity),
+      None,
+      Some(embassyAddress.postcode),
+      embassyAddress.country
+    )
+
   def registrationAddressFromAddressViewModel(addressViewModel: AddressViewModel): Address =
     Address(
       addressViewModel.street,

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/viewModels/OrganisationViewModel.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/viewModels/OrganisationViewModel.scala
@@ -34,7 +34,8 @@ object OrganisationViewModel {
       ),
       CdsOrganisationType.CharityPublicBodyNotForProfitId -> messages(
         "cds.matching.organisation-type.radio.charity-public-body-not-for-profit.label"
-      )
+      ),
+      CdsOrganisationType.EmbassyId -> messages("cds.matching.organisation-type.radio.embassy.label")
     )
 
     lazy val thirdCountryOptions = Seq(

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/check_your_details_register.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/check_your_details_register.scala.html
@@ -36,6 +36,11 @@
     cdsOrgType.contains(CdsOrganisationType.EUIndividual) || cdsOrgType.contains(CdsOrganisationType.ThirdCountryIndividual)
 }
 
+@vatHidden = @{
+    if (cdsOrgType.contains(CdsOrganisationType.Embassy)) "govuk-visually-hidden"
+    else ""
+}
+
 @layout_di(messages("cds.form.check-answers"), displayBackLink = false, service = service) {
     <div>
         <h1 class="govuk-heading-l">@messages("cds.form.check-answers")</h1>
@@ -47,7 +52,8 @@
         @if(!isIndividual){
 
         <div>
-            <h2 class="govuk-heading-m">@messages("cds.form.check-answers-vat-details")</h2>
+
+            <h2 class="govuk-heading-m @vatHidden">@messages("cds.form.check-answers-vat-details")</h2>
 
             @govukSummaryList(SummaryList(
                 rows = viewModel.vatDetails

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/embassy_address.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/embassy_address.scala.html
@@ -1,0 +1,106 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes
+@import uk.gov.hmrc.eoricommoncomponent.frontend.domain.EmbassyAddressMatchModel
+@import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
+@import uk.gov.hmrc.eoricommoncomponent.frontend.services.countries._
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.subscription.ViewHelper
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
+@import uk.gov.hmrc.govukfrontend.views.Aliases.{Button, Text}
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
+@import views.html.helper._
+
+@this(layout_di: layout,
+        govukButton: GovukButton,
+        inputText: helpers.inputText,
+        errorSummary: helpers.errorSummary,
+        countryField: helpers.countryField,
+        h1: helpers.h1,
+        govukInput: GovukInput
+)
+
+@(isInReviewMode: Boolean,
+        addressForm: Form[EmbassyAddressMatchModel],
+        countries: List[Country],
+        countriesInCountryPicker: CountriesInCountryPicker,
+        cdsOrgType: String,
+        service: Service
+)(implicit request: Request[AnyContent], messages: Messages)
+
+@layout_di(messages("cds.matching.embassy-address.title"), countriesInCountryPicker, form = Some(addressForm), service = service) {
+
+        @errorSummary(addressForm.errors)
+
+        @h1(messages("cds.matching.embassy-address.header"))
+
+        @helpers.form(routes.EmbassyAddressController.submit(isInReviewMode, service), "embassy-form") {
+        @CSRF.formField
+
+            @inputText(
+                form = addressForm,
+                id = "line-1",
+                name = "line-1",
+                label = "cds.matching.embassy-address.line-1",
+                isPageHeading = false,
+                autocomplete = Some("address-line1"),
+                classes = Some("govuk-!-width-one-half")
+            )
+            @inputText(
+                form = addressForm,
+                id = "line-2",
+                name = "line-2",
+                label = "cds.matching.embassy-address.line-2",
+                isPageHeading = false,
+                autocomplete = Some("address-line2"),
+                classes = Some("govuk-!-width-one-half")
+            )
+            @inputText(
+                form = addressForm,
+                id = "townCity",
+                name = "townCity",
+                label = "cds.matching.embassy-address.town-city",
+                isPageHeading = false,
+                autocomplete = Some("address-line3"),
+                classes = Some("govuk-!-width-one-half")
+            )
+            @inputText(
+                form = addressForm,
+                id = "postcode",
+                name = "postcode",
+                label = "cds.matching.embassy-address.postcode",
+                isPageHeading = false,
+                autocomplete = Some("postal-code"),
+                classes = Some("govuk-!-width-one-half")
+            )
+            @countryField(
+                form = addressForm,
+                field = "countryCode",
+                label = "cds.subscription.address-details.country.label",
+                countries = countries,
+                labelClasses = None
+            )
+
+
+            @govukButton(Button(
+                content = Text(ViewHelper.continueButtonText(isInReviewMode)),
+                id = Some("continue-button")
+            ))
+
+            @helpers.helpAndSupport()
+        }
+
+}

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/organisation_type.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/organisation_type.scala.html
@@ -21,10 +21,11 @@
 @import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
 @import uk.gov.hmrc.govukfrontend.views.Aliases.{Button, Text}
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukDetails
+
 @import views.html.helper._
 
-@this(layout_di: layout, inputRadioGroup: helpers.inputRadioGroup, govukButton: GovukButton, errorSummary: helpers.errorSummary)
-
+@this(layout_di: layout, inputRadioGroup: helpers.inputRadioGroup, govukButton: GovukButton, errorSummary: helpers.errorSummary, h1: helpers.h1, govukDetails : GovukDetails)
 
 @(OrganisationTypeForm: Form[CdsOrganisationType], userLocation: Option[UserLocation], service: Service)(implicit request: Request[_], messages: Messages)
 
@@ -36,16 +37,22 @@
         @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes.OrganisationTypeController.submit(service), "OrganisationTypeForm") {
             @CSRF.formField
 
+            @h1(messages("cds.matching.organisation-type.user.header"))
+
+            @govukDetails(Details(
+                summary = Text(messages("cds.matching.organisation-type.details.embassy")),
+                content = HtmlContent(messages("cds.matching.organisation-type.details.content"))
+            ))
 
             @inputRadioGroup(
                 OrganisationTypeForm("organisation-type"),
                 validOptions(userLocation),
                 hintTextOptions(userLocation).toMap,
                 None,
-                None,
+                Some("govuk-visually-hidden"),
                 '_divClass -> "govuk-form-group",
                 '_legend -> messages("cds.matching.organisation-type.user.header"),
-                '_isLegendH1 -> true)
+                '_isLegendH1 -> false)
 
             @govukButton(Button(
                 content = Text(messages("cds.navigation.continue")),

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/user_location.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/user_location.scala.html
@@ -45,7 +45,7 @@
     userLocationForm(field),
     options.map { option => (option._1, option._2) },
     options.flatMap(option => option._3.map(option._1 -> _)).toMap,
-    None,
+    Some(Html(messages("cds.registration.user-location.hint"))),
     None,
     '_divClass -> "govuk-form-group",
     '_legend -> title,

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/what_is_your_contact_address.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/what_is_your_contact_address.scala.html
@@ -1,0 +1,113 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes
+@import uk.gov.hmrc.eoricommoncomponent.frontend.domain.ContactAddressMatchModel
+@import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
+@import uk.gov.hmrc.eoricommoncomponent.frontend.services.countries._
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.subscription.ViewHelper
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
+@import uk.gov.hmrc.govukfrontend.views.Aliases.{Button, Text}
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
+@import views.html.helper._
+
+@this(layout_di: layout,
+        govukButton: GovukButton,
+        inputText: helpers.inputText,
+        errorSummary: helpers.errorSummary,
+        countryField: helpers.countryField,
+        h1: helpers.h1,
+        p: helpers.paragraph,
+        govukInput: GovukInput
+)
+
+@(isInReviewMode: Boolean,
+        addressForm: Form[ContactAddressMatchModel],
+        countries: List[Country],
+        countriesInCountryPicker: CountriesInCountryPicker,
+        cdsOrgType: String,
+        service: Service
+)(implicit request: Request[AnyContent], messages: Messages)
+
+@layout_di(messages("cds.your-contact-address.title"), countriesInCountryPicker, form = Some(addressForm), service = service) {
+
+        @errorSummary(addressForm.errors)
+
+        @h1(messages("cds.your-contact-address.header"))
+
+        <br>
+
+        @p(messages("cds.your-contact-address.info"))
+
+        <br>
+
+        @helpers.form(routes.WhatIsYourContactAddressController.submit(isInReviewMode, service), "your-contact-address-form") {
+        @CSRF.formField
+
+            @inputText(
+                form = addressForm,
+                id = "line-1",
+                name = "line-1",
+                label = "cds.your-contact-address.line-1",
+                isPageHeading = false,
+                autocomplete = Some("address-line1"),
+                classes = Some("govuk-!-width-one-half")
+            )
+            @inputText(
+                form = addressForm,
+                id = "line-2",
+                name = "line-2",
+                label = "cds.your-contact-address.line-2",
+                isPageHeading = false,
+                autocomplete = Some("address-line2"),
+                classes = Some("govuk-!-width-one-half")
+            )
+            @inputText(
+                form = addressForm,
+                id = "townCity",
+                name = "townCity",
+                label = "cds.your-contact-address.town-city",
+                isPageHeading = false,
+                autocomplete = Some("address-line3"),
+                classes = Some("govuk-!-width-one-half")
+            )
+            @inputText(
+                form = addressForm,
+                id = "postcode",
+                name = "postcode",
+                label = "cds.your-contact-address.postcode",
+                isPageHeading = false,
+                autocomplete = Some("postal-code"),
+                classes = Some("govuk-!-width-one-half")
+            )
+            @countryField(
+                form = addressForm,
+                field = "countryCode",
+                label = "cds.subscription.address-details.country.label",
+                countries = countries,
+                labelClasses = None
+            )
+
+
+            @govukButton(Button(
+                content = Text(ViewHelper.continueButtonText(isInReviewMode)),
+                id = Some("continue-button")
+            ))
+
+            @helpers.helpAndSupport()
+        }
+
+}

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/what_is_your_embassy_name.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/what_is_your_embassy_name.scala.html
@@ -1,0 +1,55 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.helpers.subscription.ViewHelper
+@import uk.gov.hmrc.eoricommoncomponent.frontend.views.html._
+@import uk.gov.hmrc.govukfrontend.views.Aliases.{Button, Text}
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
+@import views.html.helper._
+
+@this(layout_di: layout, govukButton: GovukButton, inputText: helpers.inputText, errorSummary: helpers.errorSummary)
+
+@(isInReviewMode: Boolean, embassyNameForm: Form[_ <: String], organisationType: String, service: Service)(implicit request: Request[_], messages: Messages)
+
+    @layout_di(messages("cds.matching.embassy.name.title"), form = Some(embassyNameForm), service = service) {
+    <div>
+        @errorSummary(embassyNameForm.errors)
+
+        <div class="govuk-form-group">
+            @helpers.form(uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes.EmbassyNameController.submit(isInReviewMode, organisationType, service), "embassyNameForm") {
+            @CSRF.formField
+
+                @inputText(
+                    form = embassyNameForm,
+                    id = "name",
+                    name = "name",
+                    label = "cds.matching.embassy.name.heading",
+                    isPageHeading = true,
+                    classes = Some("govuk-!-width-two-thirds"),
+                    labelClasses = Some("govuk-label govuk-label--l")
+                )
+
+                @govukButton(Button(
+                    content = Text(ViewHelper.continueButtonText(isInReviewMode)),
+                    id = Some("continue-button")
+                ))
+
+                @helpers.helpAndSupport()
+            }
+        </div>
+    </div>
+    }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -524,6 +524,7 @@ cds.registration.user-location.location.islands.label=The Channel Islands
 cds.registration.user-location.location.islands-or-iom.label=Channel Islands or the Isle of Man
 cds.registration.user-location.location.eu.summary=Countries in the EU
 cds.registration.user-location.location.eu.hint=When trading, Channel Islands, Isle of Man, Akrotiri and Dhekelia, Faroe Islands are within the EU customs union.
+cds.registration.user-location.hint=This should be the location of the address you want to use for your EORI number registration.
 
 # Pre Journey Checks
 cds.registration.based-in-uk.title=Are you or your organisation based in the UK?
@@ -559,6 +560,11 @@ cds.matching.organisation-type.radio.individual.hint-text=Someone who is moving 
 cds.matching.organisation-type.radio.partnership.label=Partnership
 cds.matching.organisation-type.radio.limited-liability-partnership.label=Limited Liability Partnership
 cds.matching.organisation-type.radio.charity-public-body-not-for-profit.label=Charity, public body or not for profit organisation
+cds.matching.organisation-type.radio.embassy.label=Embassy
+cds.matching.organisation-type.details.embassy=Help with these options
+cds.matching.organisation-type.details.content=<p>This is the business type you chose when you set up a business or registered with HMRC.</p>\
+<p>If your business is registered with Companies House, you can check your company type on your Companies House profile.</p>\
+<p><a class="govuk-link" target="_blank" href="https://beta.companieshouse.gov.uk/">Search Companies House for company information (opens in new tab).</a></p>
 
 cds.matching.organisation-type.radio.eu-organisation.label=EU Organisation
 cds.matching.organisation-type.radio.eu-individual.label=EU Individual
@@ -1174,6 +1180,7 @@ cds.form.partner-address=Partnership address
 cds.form.company-address=Company address
 cds.form.organisation-address=Organisation address
 cds.form.business-details=Registered company address
+cds.form.embassy-address=Embassy’s address
 cds.form.shortened-name=Shortened name
 cds.form.sic-code=Standard Industrial Classification (SIC) code
 cds.form.gb-vat-number=VAT number
@@ -1193,6 +1200,7 @@ cds.form.check-answers.contact-telephone=Contact telephone
 cds.form.check-answers-company-details=Company details
 cds.form.check-answers-your-details=Your details
 cds.form.check-answers-partnership-details=Partnership details
+cds.form.check-answers-embassy-details=Embassy details
 cds.form.check-answers-organisation-details=Organisation details
 cds.form.check-answers-vat-details=VAT details
 cds.form.check-answers-contact-details=Contact details
@@ -1360,6 +1368,7 @@ cds.review-page.fax-prefix=fax:
 cds.registration.reg06.fail=Submission Failed
 cds.business-name.label=Registered company name
 cds.organisation-name.label=Organisation name
+cds.embassy-name.label=Embassy’s name
 cds.partner-name.label=Registered partnership name
 cds.check-your-details.utrnumber=Corporation Tax UTR number
 cds.check-your-details.utrnumber.partnership=Partnership Self Assessment UTR
@@ -2086,3 +2095,30 @@ cds.matching.ind-st-cannot-register-using-service.para1=This service is not avai
 cds.matching.ind-st-cannot-register-using-service.para2=You can:
 cds.matching.ind-st-cannot-register-using-service.link.text1=apply for an EORI number if you are VAT registered
 cds.matching.ind-st-cannot-register-using-service.link.text2=apply for an EORI number if you are not VAT registered
+
+#Embassy Name
+cds.matching.embassy.name.title=What is the embassy’s name?
+cds.matching.embassy.name.heading=What is the embassy’s name?
+cds.matching.embassy-name.error.name=Enter your registered embassy name
+cds.matching-error.business-details.embassy-name.invalid-char=Embassy name cannot contain ''<'' or ''>''
+
+#Embassy Address
+cds.matching.embassy-address.title=What is the embassy’s address?
+cds.matching.embassy-address.header=What is the embassy’s address?
+cds.matching.embassy-address.line-1=Address line 1
+cds.matching.embassy-address.line-2=Address line 2 (optional)
+cds.matching.embassy-address.town-city=Town or city
+cds.matching.embassy-address.postcode=Postcode
+cds.matching.embassy-address.line-1.error.empty=Enter the first line of your address
+cds.matching.embassy-address.line.error.invalid-chars=Address line cannot contain ''<'' or ''>''
+cds.matching.embassy-address.town-city.error.empty=Enter your town or city
+cds.matching.embassy-address.town-city.error.too-long=The town or city must be 35 characters or less
+
+#Your Contact Address
+cds.your-contact-address.title=What is your contact address?
+cds.your-contact-address.header=What is your contact address?
+cds.your-contact-address.info=We will use this address to contact you about this EORI number application.
+cds.your-contact-address.line-1=Address line 1
+cds.your-contact-address.line-2=Address line 2 (optional)
+cds.your-contact-address.town-city=Town or city
+cds.your-contact-address.postcode=Postcode

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -108,12 +108,18 @@ GET         /customs-registration-services/:service/register/matching/address/:o
 POST        /customs-registration-services/:service/register/matching/address/:organisationType          @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.SixLineAddressController.submit(isInReviewMode: Boolean = false, organisationType, service: Service)
 GET         /customs-registration-services/:service/register/matching/address/:organisationType/review   @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.SixLineAddressController.showForm(isInReviewMode: Boolean = true, organisationType, service: Service)
 POST        /customs-registration-services/:service/register/matching/address/:organisationType/review   @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.SixLineAddressController.submit(isInReviewMode: Boolean = true, organisationType, service: Service)
-
-
+GET         /customs-registration-services/:service/register/matching/embassy-address                    @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.EmbassyAddressController.showForm(isInReviewMode: Boolean = false, service: Service)
+POST        /customs-registration-services/:service/register/matching/embassy-address                    @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.EmbassyAddressController.submit(isInReviewMode: Boolean = false, service: Service)
+GET         /customs-registration-services/:service/register/matching/embassy-address/review             @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.EmbassyAddressController.showForm(isInReviewMode: Boolean = true, service: Service)
+POST        /customs-registration-services/:service/register/matching/embassy-address/review             @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.EmbassyAddressController.submit(isInReviewMode: Boolean = true, service: Service)
 GET         /customs-registration-services/:service/register/address                                     @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.AddressController.createForm(service: Service)
 POST        /customs-registration-services/:service/register/address                                     @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.AddressController.submit(isInReviewMode:Boolean = false, service: Service)
 GET         /customs-registration-services/:service/register/address/review                              @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.AddressController.reviewForm(service: Service)
 POST        /customs-registration-services/:service/register/address/review                              @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.AddressController.submit(isInReviewMode:Boolean = true, service: Service)
+
+GET         /customs-registration-services/:service/register/your-contact-address                                     @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.WhatIsYourContactAddressController.showForm(isInReviewMode:Boolean = false, service: Service)
+POST        /customs-registration-services/:service/register/your-contact-address                                     @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.WhatIsYourContactAddressController.submit(isInReviewMode:Boolean = false, service: Service)
+POST        /customs-registration-services/:service/register/your-contact-address/review                              @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.WhatIsYourContactAddressController.submit(isInReviewMode:Boolean = true, service: Service)
 
 GET         /customs-registration-services/:service/register/matching/:organisationType                  @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.NameIdOrganisationController.form(organisationType, service: Service)
 POST        /customs-registration-services/:service/register/matching/:organisationType                  @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.NameIdOrganisationController.submit(organisationType, service: Service)
@@ -121,6 +127,12 @@ GET         /customs-registration-services/:service/register/matching/name/:orga
 POST        /customs-registration-services/:service/register/matching/name/:organisationType             @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.WhatIsYourOrgNameController.submit(isInReviewMode: Boolean = false, organisationType, service: Service)
 GET         /customs-registration-services/:service/register/matching/name/:organisationType/review      @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.WhatIsYourOrgNameController.showForm(isInReviewMode: Boolean = true,organisationType, service: Service)
 POST        /customs-registration-services/:service/register/matching/name/:organisationType/review      @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.WhatIsYourOrgNameController.submit(isInReviewMode: Boolean = true, organisationType, service: Service)
+
+GET         /customs-registration-services/:service/register/matching/embassy-name/:organisationType             @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.EmbassyNameController.showForm(isInReviewMode: Boolean = false, organisationType, service: Service)
+POST        /customs-registration-services/:service/register/matching/embassy-name/:organisationType             @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.EmbassyNameController.submit(isInReviewMode: Boolean = false, organisationType, service: Service)
+GET         /customs-registration-services/:service/register/matching/embassy-name/:organisationType/review      @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.EmbassyNameController.showForm(isInReviewMode: Boolean = true,organisationType, service: Service)
+POST        /customs-registration-services/:service/register/matching/embassy-name/:organisationType/review      @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.EmbassyNameController.submit(isInReviewMode: Boolean = true, organisationType, service: Service)
+
 GET         /customs-registration-services/:service/register/matching/utr/:organisationType              @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.DoYouHaveAUtrNumberController.form(organisationType, service: Service, isInReviewMode: Boolean = false)
 POST        /customs-registration-services/:service/register/matching/utr/:organisationType              @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.DoYouHaveAUtrNumberController.submit(organisationType, service: Service, isInReviewMode: Boolean = false)
 GET         /customs-registration-services/:service/register/matching/utr/:organisationType/review       @uk.gov.hmrc.eoricommoncomponent.frontend.controllers.DoYouHaveAUtrNumberController.form(organisationType, service: Service, isInReviewMode: Boolean = true)

--- a/test/unit/controllers/CdsPage.scala
+++ b/test/unit/controllers/CdsPage.scala
@@ -32,7 +32,7 @@ case class CdsPage(html: String) {
   def getElementValue(xpath: String): String =
     selectElement(xpath).`val`()
 
-  def getElementById(id: String) = page.getElementById(id)
+  def getElementById(id: String): Element = page.getElementById(id)
 
   def getElementValueForLabel(labelXpath: String): String = {
     val elementId = getElementAttributeFor(labelXpath)

--- a/test/unit/controllers/EmbassyAddressControllerSpec.scala
+++ b/test/unit/controllers/EmbassyAddressControllerSpec.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.controllers
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.BeforeAndAfterEach
+import play.api.http.Status.OK
+import play.api.mvc.Session
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.{EmbassyAddressController, SubscriptionFlowManager}
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.{RegistrationDetailsEmbassy, SafeId}
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.Address
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.EoriConsentSubscriptionFlowPage
+import uk.gov.hmrc.eoricommoncomponent.frontend.forms.embassy.EmbassyAddressForm
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.RegistrationDetailsService
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{RequestSessionData, SessionCache}
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.mapping.RegistrationDetailsCreator
+import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.embassy_address
+import util.ControllerSpec
+import util.builders.AuthBuilder.withAuthorisedUser
+import util.builders.{AuthActionMock, SessionBuilder}
+
+import java.util.UUID
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class EmbassyAddressControllerSpec extends ControllerSpec with BeforeAndAfterEach with AuthActionMock {
+
+  private val mockAuthConnector              = mock[AuthConnector]
+  private val mockAuthAction                 = authAction(mockAuthConnector)
+  private val mockSessionCache               = mock[SessionCache]
+  private val mockRequestSessionData         = mock[RequestSessionData]
+  private val mockRegDetailsCreator          = mock[RegistrationDetailsCreator]
+  private val mockRegistrationDetailsService = mock[RegistrationDetailsService]
+  private val mockSubscriptionFlowManager    = mock[SubscriptionFlowManager]
+  private val embassyAddressForm             = new EmbassyAddressForm()
+  private val embassyAddressView             = instanceOf[embassy_address]
+
+  private val fieldLevelErrorAddress         = "//p[@id='address-error' and @class='govuk-error-message']"
+  private val pageLevelErrorSummaryListXPath = "//ul[@class='govuk-list govuk-error-summary__list']"
+  private val lineOneFieldError              = "//p[@id='line-1-error' and @class='govuk-error-message']"
+  private val lineTwoFieldError              = "//p[@id='line-2-error' and @class='govuk-error-message']"
+  private val townCityFieldError             = "//p[@id='townCity-error' and @class='govuk-error-message']"
+  private val postcodeFieldError             = "//p[@id='postcode-error' and @class='govuk-error-message']"
+
+  private val embassyAddressController = new EmbassyAddressController(
+    mockAuthAction,
+    mockSessionCache,
+    mockRequestSessionData,
+    mcc,
+    mockRegDetailsCreator,
+    mockRegistrationDetailsService,
+    mockSubscriptionFlowManager,
+    embassyAddressForm,
+    embassyAddressView
+  )
+
+  "showForm" should {
+    "render empty form with no data" in {
+      // Given
+      val userId = UUID.randomUUID().toString
+      withAuthorisedUser(userId, mockAuthConnector)
+      when(mockSessionCache.registrationDetails(any())).thenReturn(
+        Future.successful(RegistrationDetailsEmbassy.initEmpty())
+      )
+
+      // When
+      val result = embassyAddressController.showForm(isInReviewMode = false, eoriOnlyService)
+        .apply(SessionBuilder.buildRequestWithSession(userId))
+
+      // Then
+      status(result) shouldBe OK
+      val page: CdsPage = CdsPage(contentAsString(result))
+      page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe empty
+      page.getElementsText(fieldLevelErrorAddress) shouldBe empty
+      page.h1() shouldBe "What is the embassy’s address?"
+      page.title() shouldBe "What is the embassy’s address? - Get an EORI number - GOV.UK"
+      page.getElementById("line-1").attr("value") shouldBe empty
+      page.getElementById("line-2").attr("value") shouldBe empty
+      page.getElementById("townCity").attr("value") shouldBe empty
+      page.getElementById("postcode").attr("value") shouldBe empty
+      page.getElementById("countryCode").attr("value") shouldBe empty
+    }
+
+    "render existing data in form from database" in {
+      // Given
+      val userId = UUID.randomUUID().toString
+      withAuthorisedUser(userId, mockAuthConnector)
+      when(mockSessionCache.registrationDetails(any())).thenReturn(
+        Future.successful(
+          RegistrationDetailsEmbassy.apply(
+            "Embassy Of Japan",
+            Address("101-104 Piccadilly", Some("Greater London"), Some("London"), None, Some("SW3 5DA"), "GB"),
+            None,
+            SafeId("")
+          )
+        )
+      )
+
+      // When
+      val result = embassyAddressController.showForm(isInReviewMode = false, eoriOnlyService)
+        .apply(SessionBuilder.buildRequestWithSession(userId))
+
+      // Then
+      status(result) shouldBe OK
+      val page: CdsPage = CdsPage(contentAsString(result))
+      page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe empty
+      page.getElementsText(fieldLevelErrorAddress) shouldBe empty
+      page.h1() shouldBe "What is the embassy’s address?"
+      page.title() shouldBe "What is the embassy’s address? - Get an EORI number - GOV.UK"
+      page.getElementById("line-1").attr("value") shouldBe "101-104 Piccadilly"
+      page.getElementById("line-2").attr("value") shouldBe "Greater London"
+      page.getElementById("townCity").attr("value") shouldBe "London"
+      page.getElementById("postcode").attr("value") shouldBe "SW3 5DA"
+      page.getElementById("countryCode").attr("value") shouldBe empty
+    }
+  }
+
+  "submit" should {
+    "show errors" when {
+      "no data entered" in {
+        // Given
+        val userId = UUID.randomUUID().toString
+        withAuthorisedUser(userId, mockAuthConnector)
+        when(mockSessionCache.registrationDetails(any())).thenReturn(
+          Future.successful(RegistrationDetailsEmbassy.initEmpty())
+        )
+
+        // When
+        val result = embassyAddressController.submit(isInReviewMode = false, eoriOnlyService)
+          .apply(
+            SessionBuilder.buildRequestWithSessionAndFormValues(
+              userId,
+              Map("line-1" -> "", "line-2" -> "", "townCity" -> "", "postcode" -> "", "countryCode" -> "")
+            )
+          )
+
+        // Then
+        status(result) shouldBe BAD_REQUEST
+        val page = CdsPage(contentAsString(result))
+        page.getElementsText(
+          pageLevelErrorSummaryListXPath
+        ) shouldBe "Enter the first line of your address Enter your town or city Enter a valid postcode"
+        page.getElementsText(lineOneFieldError) shouldBe "Error: Enter the first line of your address"
+        page.getElementsText(townCityFieldError) shouldBe "Error: Enter your town or city"
+        page.getElementsText(postcodeFieldError) shouldBe "Error: Enter a valid postcode"
+        page.getElementsText("title") should startWith("Error: ")
+      }
+
+      "invalid data entered" in {
+        // Given
+        val userId = UUID.randomUUID().toString
+        withAuthorisedUser(userId, mockAuthConnector)
+        when(mockSessionCache.registrationDetails(any())).thenReturn(
+          Future.successful(RegistrationDetailsEmbassy.initEmpty())
+        )
+
+        // When
+        val result = embassyAddressController.submit(isInReviewMode = false, eoriOnlyService)
+          .apply(
+            SessionBuilder.buildRequestWithSessionAndFormValues(
+              userId,
+              Map(
+                "line-1"      -> "<somewhere>",
+                "line-2"      -> "<someplace>",
+                "townCity"    -> "a really really long town city name somewhere",
+                "postcode"    -> "FakePostcode",
+                "countryCode" -> "GB"
+              )
+            )
+          )
+
+        // Then
+        status(result) shouldBe BAD_REQUEST
+        val page = CdsPage(contentAsString(result))
+        page.getElementsText(
+          pageLevelErrorSummaryListXPath
+        ) shouldBe "Address line cannot contain '<' or '>' Address line cannot contain '<' or '>' The town or city must be 35 characters or less Enter a valid postcode"
+        page.getElementsText(lineOneFieldError) shouldBe "Error: Address line cannot contain '<' or '>'"
+        page.getElementsText(lineTwoFieldError) shouldBe "Error: Address line cannot contain '<' or '>'"
+        page.getElementsText(townCityFieldError) shouldBe "Error: The town or city must be 35 characters or less"
+        page.getElementsText(postcodeFieldError) shouldBe "Error: Enter a valid postcode"
+        page.getElementsText("title") should startWith("Error: ")
+      }
+    }
+
+    "redirect" when {
+      "in review mode" in {
+        val userId = UUID.randomUUID().toString
+        withAuthorisedUser(userId, mockAuthConnector)
+        when(mockRegistrationDetailsService.cacheAddress(any())(any())).thenReturn(Future.successful(true))
+        when(mockRegDetailsCreator.registrationAddressEmbassyAddress(any())).thenReturn(
+          Address("101-104 Piccadilly", Some("Greater London"), Some("London"), None, Some("SW3 5DA"), "GB")
+        )
+
+        val result = embassyAddressController.submit(isInReviewMode = true, eoriOnlyService)
+          .apply(
+            SessionBuilder.buildRequestWithSessionAndFormValues(
+              userId,
+              Map(
+                "line-1"      -> "101-104 Piccadilly",
+                "line-2"      -> "Greater London",
+                "townCity"    -> "London",
+                "postcode"    -> "SW3 5DA",
+                "countryCode" -> "GB"
+              )
+            )
+          )
+
+        status(result) shouldBe SEE_OTHER
+        header(
+          LOCATION,
+          result
+        ).value shouldBe "/customs-registration-services/eori-only/register/matching/review-determine"
+      }
+
+      "not in review mode" in {
+        val userId = UUID.randomUUID().toString
+        withAuthorisedUser(userId, mockAuthConnector)
+        when(mockRegistrationDetailsService.cacheAddress(any())(any())).thenReturn(Future.successful(true))
+        when(mockRegDetailsCreator.registrationAddressEmbassyAddress(any())).thenReturn(
+          Address("101-104 Piccadilly", Some("Greater London"), Some("London"), None, Some("SW3 5DA"), "GB")
+        )
+        when(mockSubscriptionFlowManager.startSubscriptionFlow(any())(any())).thenReturn(
+          Future.successful((EoriConsentSubscriptionFlowPage, Session()))
+        )
+
+        val result = embassyAddressController.submit(isInReviewMode = false, eoriOnlyService)
+          .apply(
+            SessionBuilder.buildRequestWithSessionAndFormValues(
+              userId,
+              Map(
+                "line-1"      -> "101-104 Piccadilly",
+                "line-2"      -> "Greater London",
+                "townCity"    -> "London",
+                "postcode"    -> "SW3 5DA",
+                "countryCode" -> "GB"
+              )
+            )
+          )
+
+        status(result) shouldBe SEE_OTHER
+        header(
+          LOCATION,
+          result
+        ).value shouldBe "/customs-registration-services/eori-only/register/disclose-personal-details-consent"
+      }
+    }
+  }
+}

--- a/test/unit/controllers/EmbassyNameControllerSpec.scala
+++ b/test/unit/controllers/EmbassyNameControllerSpec.scala
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.controllers
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.BeforeAndAfterEach
+import play.api.http.Status.OK
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.EmbassyNameController
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.CdsOrganisationType.EmbassyId
+import uk.gov.hmrc.eoricommoncomponent.frontend.forms.embassy.EmbassyNameForm
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.SubscriptionDetailsService
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.RequestSessionData
+import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.what_is_your_embassy_name
+import util.ControllerSpec
+import util.builders.AuthBuilder.withAuthorisedUser
+import util.builders.{AuthActionMock, SessionBuilder}
+
+import java.util.UUID
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class EmbassyNameControllerSpec extends ControllerSpec with BeforeAndAfterEach with AuthActionMock {
+
+  private val mockAuthConnector              = mock[AuthConnector]
+  private val mockAuthAction                 = authAction(mockAuthConnector)
+  private val form                           = new EmbassyNameForm()
+  private val mockSubscriptionDetailsService = mock[SubscriptionDetailsService]
+  private val mockEmbassyNameView            = instanceOf[what_is_your_embassy_name]
+  private val mockRequestSessionData         = mock[RequestSessionData]
+
+  private val embassyNameController = new EmbassyNameController(
+    mockAuthAction,
+    mcc,
+    form,
+    mockEmbassyNameView,
+    mockSubscriptionDetailsService,
+    mockRequestSessionData
+  )
+
+  private val fieldLevelErrorName            = "//p[@id='name-error' and @class='govuk-error-message']"
+  private val pageLevelErrorSummaryListXPath = "//ul[@class='govuk-list govuk-error-summary__list']"
+  private val nameFieldError                 = "//p[@id='name-error' and @class='govuk-error-message']"
+
+  "showForm" should {
+    "show the embassy name form" in {
+      // Given
+      val userId = UUID.randomUUID().toString
+      withAuthorisedUser(userId, mockAuthConnector)
+      when(mockSubscriptionDetailsService.cachedEmbassyName(any())).thenReturn(Future.successful(None))
+
+      // When
+      val result = embassyNameController.showForm(isInReviewMode = false, EmbassyId, eoriOnlyService)
+        .apply(SessionBuilder.buildRequestWithSession(userId))
+
+      // Then
+      status(result) shouldBe OK
+      val page: CdsPage = CdsPage(contentAsString(result))
+      page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe empty
+      page.getElementsText(fieldLevelErrorName) shouldBe empty
+      page.title() shouldBe "What is the embassy’s name? - Get an EORI number - GOV.UK"
+      page.h1() shouldBe "What is the embassy’s name?"
+      page.getElementById("name").text() shouldBe empty
+    }
+
+    "show the embassy name form with embassy name populated in input text" in {
+      // Given
+      val userId = UUID.randomUUID().toString
+      withAuthorisedUser(userId, mockAuthConnector)
+      when(mockSubscriptionDetailsService.cachedEmbassyName(any())).thenReturn(Future.successful(Some("U.S. Embassy")))
+
+      // When
+      val result = embassyNameController.showForm(isInReviewMode = false, EmbassyId, eoriOnlyService)
+        .apply(SessionBuilder.buildRequestWithSession(userId))
+
+      // Then
+      status(result) shouldBe OK
+      val page: CdsPage = CdsPage(contentAsString(result))
+      page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe empty
+      page.getElementsText(fieldLevelErrorName) shouldBe empty
+      page.title() shouldBe "What is the embassy’s name? - Get an EORI number - GOV.UK"
+      page.h1() shouldBe "What is the embassy’s name?"
+      page.getElementById("name").attr("value") shouldBe "U.S. Embassy"
+    }
+  }
+
+  "submit" should {
+    "show errors" when {
+      "invalid data entered" in {
+        // Given
+        val userId = UUID.randomUUID().toString
+        withAuthorisedUser(userId, mockAuthConnector)
+        when(mockSubscriptionDetailsService.cachedEmbassyName(any())).thenReturn(Future.successful(None))
+
+        // When
+        val result = embassyNameController
+          .submit(isInReviewMode = false, EmbassyId, eoriOnlyService)
+          .apply(SessionBuilder.buildRequestWithSessionAndFormValues(userId, Map("name" -> "<Embassy Of Japan>")))
+
+        // Then
+        status(result) shouldBe BAD_REQUEST
+        val page = CdsPage(contentAsString(result))
+        page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe "Embassy name cannot contain '<' or '>'"
+        page.getElementsText(nameFieldError) shouldBe "Error: Embassy name cannot contain '<' or '>'"
+        page.getElementsText("title") should startWith("Error: ")
+      }
+
+      "no data entered" in {
+        // Given
+        val userId = UUID.randomUUID().toString
+        withAuthorisedUser(userId, mockAuthConnector)
+        when(mockSubscriptionDetailsService.cachedEmbassyName(any())).thenReturn(Future.successful(None))
+
+        // When
+        val result = embassyNameController
+          .submit(isInReviewMode = false, EmbassyId, eoriOnlyService)
+          .apply(SessionBuilder.buildRequestWithSessionAndFormValues(userId, Map("name" -> "")))
+
+        // Then
+        status(result) shouldBe BAD_REQUEST
+        val page = CdsPage(contentAsString(result))
+        page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe "Enter your registered embassy name"
+        page.getElementsText(nameFieldError) shouldBe "Error: Enter your registered embassy name"
+        page.getElementsText("title") should startWith("Error: ")
+      }
+    }
+
+    "redirect" when {
+      "in review mode to embassy address page" in {
+        // Given
+        val userId = UUID.randomUUID().toString
+        withAuthorisedUser(userId, mockAuthConnector)
+        when(mockSubscriptionDetailsService.cachedEmbassyName(any())).thenReturn(Future.successful(None))
+        when(mockSubscriptionDetailsService.cacheEmbassyName(any())(any())).thenReturn(Future.unit)
+
+        // When
+        val result = embassyNameController
+          .submit(isInReviewMode = true, EmbassyId, eoriOnlyService)
+          .apply(SessionBuilder.buildRequestWithSessionAndFormValues(userId, Map("name" -> "Embassy Of Japan")))
+
+        status(result) shouldBe SEE_OTHER
+        header(
+          LOCATION,
+          result
+        ).value shouldBe "/customs-registration-services/eori-only/register/matching/review-determine"
+      }
+
+      "not in review mode to error page" in {
+        // Given
+        val userId = UUID.randomUUID().toString
+        withAuthorisedUser(userId, mockAuthConnector)
+        when(mockSubscriptionDetailsService.cachedEmbassyName(any())).thenReturn(Future.successful(None))
+        when(mockSubscriptionDetailsService.cacheEmbassyName(any())(any())).thenReturn(Future.unit)
+        when(mockSubscriptionDetailsService.updateSubscriptionDetailsEmbassyName(any())(any())).thenReturn(Future.unit)
+
+        // When
+        val result = embassyNameController
+          .submit(isInReviewMode = false, EmbassyId, eoriOnlyService)
+          .apply(SessionBuilder.buildRequestWithSessionAndFormValues(userId, Map("name" -> "Embassy Of Japan")))
+
+        status(result) shouldBe SEE_OTHER
+        header(
+          LOCATION,
+          result
+        ).value shouldBe "/customs-registration-services/eori-only/register/matching/embassy-address"
+      }
+    }
+  }
+
+}

--- a/test/unit/controllers/WhatIsYourContactAddressControllerSpec.scala
+++ b/test/unit/controllers/WhatIsYourContactAddressControllerSpec.scala
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.controllers
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.BeforeAndAfterEach
+import play.api.http.Status.OK
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.WhatIsYourContactAddressController
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.SubscriptionDetailsService
+import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.RequestSessionData
+import uk.gov.hmrc.eoricommoncomponent.frontend.views.html.what_is_your_contact_address
+import util.ControllerSpec
+import util.builders.AuthBuilder.withAuthorisedUser
+import util.builders.{AuthActionMock, SessionBuilder}
+
+import java.util.UUID
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class WhatIsYourContactAddressControllerSpec extends ControllerSpec with BeforeAndAfterEach with AuthActionMock {
+
+  private val mockAuthConnector              = mock[AuthConnector]
+  private val mockAuthAction                 = authAction(mockAuthConnector)
+  private val mockRequestSessionData         = mock[RequestSessionData]
+  private val mockSubscriptionDetailsService = mock[SubscriptionDetailsService]
+  private val whatIsYourContactAddressView   = instanceOf[what_is_your_contact_address]
+
+  private val controller = new WhatIsYourContactAddressController(
+    mockAuthAction,
+    mcc,
+    mockRequestSessionData,
+    mockSubscriptionDetailsService,
+    whatIsYourContactAddressView
+  )
+
+  private val fieldLevelErrorAddress         = "//p[@id='address-error' and @class='govuk-error-message']"
+  private val pageLevelErrorSummaryListXPath = "//ul[@class='govuk-list govuk-error-summary__list']"
+  private val lineOneFieldError              = "//p[@id='line-1-error' and @class='govuk-error-message']"
+  private val lineTwoFieldError              = "//p[@id='line-2-error' and @class='govuk-error-message']"
+  private val townCityFieldError             = "//p[@id='townCity-error' and @class='govuk-error-message']"
+  private val postcodeFieldError             = "//p[@id='postcode-error' and @class='govuk-error-message']"
+
+  "showForm" should {
+    "render empty form with no data" in {
+      // Given
+      val userId = UUID.randomUUID().toString
+      withAuthorisedUser(userId, mockAuthConnector)
+
+      // When
+      val result = controller.showForm(isInReviewMode = false, eoriOnlyService)
+        .apply(SessionBuilder.buildRequestWithSession(userId))
+
+      // Then
+      status(result) shouldBe OK
+      val page: CdsPage = CdsPage(contentAsString(result))
+      page.getElementsText(pageLevelErrorSummaryListXPath) shouldBe empty
+      page.getElementsText(fieldLevelErrorAddress) shouldBe empty
+      page.h1() shouldBe "What is your contact address?"
+      page.title() shouldBe "What is your contact address? - Get an EORI number - GOV.UK"
+      page.getElementById("line-1").attr("value") shouldBe empty
+      page.getElementById("line-2").attr("value") shouldBe empty
+      page.getElementById("townCity").attr("value") shouldBe empty
+      page.getElementById("postcode").attr("value") shouldBe empty
+      page.getElementById("countryCode").attr("value") shouldBe empty
+    }
+  }
+
+  "submit" should {
+    "show errors" when {
+      "no data entered" in {
+        // Given
+        val userId = UUID.randomUUID().toString
+        withAuthorisedUser(userId, mockAuthConnector)
+
+        // When
+        val result = controller.submit(isInReviewMode = false, eoriOnlyService)
+          .apply(
+            SessionBuilder.buildRequestWithSessionAndFormValues(
+              userId,
+              Map("line-1" -> "", "line-2" -> "", "townCity" -> "", "postcode" -> "", "countryCode" -> "")
+            )
+          )
+
+        // Then
+        status(result) shouldBe BAD_REQUEST
+        val page = CdsPage(contentAsString(result))
+        page.getElementsText(
+          pageLevelErrorSummaryListXPath
+        ) shouldBe "Enter the first line of your address Enter your town or city Enter a valid postcode"
+        page.getElementsText(lineOneFieldError) shouldBe "Error: Enter the first line of your address"
+        page.getElementsText(townCityFieldError) shouldBe "Error: Enter your town or city"
+        page.getElementsText(postcodeFieldError) shouldBe "Error: Enter a valid postcode"
+        page.getElementsText("title") should startWith("Error: ")
+      }
+
+      "invalid data entered" in {
+        // Given
+        val userId = UUID.randomUUID().toString
+        withAuthorisedUser(userId, mockAuthConnector)
+
+        // When
+        val result = controller.submit(isInReviewMode = false, eoriOnlyService)
+          .apply(
+            SessionBuilder.buildRequestWithSessionAndFormValues(
+              userId,
+              Map(
+                "line-1"      -> "<somewhere>",
+                "line-2"      -> "<someplace>",
+                "townCity"    -> "a really really long town city name somewhere",
+                "postcode"    -> "FakePostcode",
+                "countryCode" -> "GB"
+              )
+            )
+          )
+
+        // Then
+        status(result) shouldBe BAD_REQUEST
+        val page = CdsPage(contentAsString(result))
+        page.getElementsText(
+          pageLevelErrorSummaryListXPath
+        ) shouldBe "Address line cannot contain '<' or '>' Address line cannot contain '<' or '>' The town or city must be 35 characters or less Enter a valid postcode"
+        page.getElementsText(lineOneFieldError) shouldBe "Error: Address line cannot contain '<' or '>'"
+        page.getElementsText(lineTwoFieldError) shouldBe "Error: Address line cannot contain '<' or '>'"
+        page.getElementsText(townCityFieldError) shouldBe "Error: The town or city must be 35 characters or less"
+        page.getElementsText(postcodeFieldError) shouldBe "Error: Enter a valid postcode"
+        page.getElementsText("title") should startWith("Error: ")
+      }
+    }
+
+    "redirect" when {
+      "in review mode" in {
+        val userId = UUID.randomUUID().toString
+        withAuthorisedUser(userId, mockAuthConnector)
+        when(mockSubscriptionDetailsService.cacheAddressDetails(any())(any())).thenReturn(Future.unit)
+
+        val result = controller.submit(isInReviewMode = true, eoriOnlyService)
+          .apply(
+            SessionBuilder.buildRequestWithSessionAndFormValues(
+              userId,
+              Map(
+                "line-1"      -> "101-104 Piccadilly",
+                "line-2"      -> "Greater London",
+                "townCity"    -> "London",
+                "postcode"    -> "SW3 5DA",
+                "countryCode" -> "GB"
+              )
+            )
+          )
+
+        status(result) shouldBe SEE_OTHER
+        header(
+          LOCATION,
+          result
+        ).value shouldBe "/customs-registration-services/eori-only/register/contact-address/review"
+      }
+
+      "not in review mode" in {
+        val userId = UUID.randomUUID().toString
+        withAuthorisedUser(userId, mockAuthConnector)
+        when(mockSubscriptionDetailsService.cacheAddressDetails(any())(any())).thenReturn(Future.unit)
+
+        val result = controller.submit(isInReviewMode = false, eoriOnlyService)
+          .apply(
+            SessionBuilder.buildRequestWithSessionAndFormValues(
+              userId,
+              Map(
+                "line-1"      -> "101-104 Piccadilly",
+                "line-2"      -> "Greater London",
+                "townCity"    -> "London",
+                "postcode"    -> "SW3 5DA",
+                "countryCode" -> "GB"
+              )
+            )
+          )
+
+        status(result) shouldBe SEE_OTHER
+        header(LOCATION, result).value shouldBe "/customs-registration-services/eori-only/register/contact-address"
+      }
+    }
+  }
+
+}

--- a/test/unit/domain/RegistrationDetailsFormatSpec.scala
+++ b/test/unit/domain/RegistrationDetailsFormatSpec.scala
@@ -142,6 +142,31 @@ class RegistrationDetailsFormatSpec extends UnitSpec {
       |}
     """.stripMargin)
 
+  val embassyDetailsJson: JsValue = Json.parse("""
+      |{
+      |  "orgType": "embassy",
+      |  "name": "Embassy Of Japan",
+      |  "address": {
+      |    "addressLine1": "101-104 Piccadilly",
+      |    "addressLine2": "Greater London",
+      |    "addressLine3": "London",
+      |    "postalCode": "W1J 7JT",
+      |    "countryCode": "GB"
+      |  },
+      |  "customsId": null,
+      |  "safeId": {
+      |    "id": ""
+      |  }
+      |}
+      |""".stripMargin)
+
+  val embassyDetails: RegistrationDetailsEmbassy = RegistrationDetailsEmbassy.apply(
+    "Embassy Of Japan",
+    Address("101-104 Piccadilly", Some("Greater London"), Some("London"), None, Some("W1J 7JT"), "GB"),
+    None,
+    SafeId("")
+  )
+
   "RegistrationDetails formats" should {
 
     "marshall organisation details" in {
@@ -166,6 +191,14 @@ class RegistrationDetailsFormatSpec extends UnitSpec {
 
     "unmarshall individual details" in {
       unmarshall(individualJson) shouldBe JsSuccess(individualDetails)
+    }
+
+    "marshall embassy details" in {
+      Json.prettyPrint(marshall(embassyDetails)) shouldBe Json.prettyPrint(embassyDetailsJson)
+    }
+
+    "unmarshall embassy details" in {
+      unmarshall(embassyDetailsJson) shouldBe JsSuccess(embassyDetails)
     }
   }
 

--- a/test/unit/domain/SubscriptionFlowSpec.scala
+++ b/test/unit/domain/SubscriptionFlowSpec.scala
@@ -17,13 +17,20 @@
 package unit.domain
 
 import base.UnitSpec
-import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.{OrganisationSubscriptionFlow, SubscriptionFlow}
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.{
+  EmbassySubscriptionFlow,
+  IndividualSubscriptionFlow,
+  OrganisationSubscriptionFlow,
+  SubscriptionFlow
+}
 
 class SubscriptionFlowSpec extends UnitSpec {
 
   "SubscriptionFlow object" should {
     "create for valid flow name" in {
       SubscriptionFlow("Organisation") shouldBe OrganisationSubscriptionFlow
+      SubscriptionFlow("Individual") shouldBe IndividualSubscriptionFlow
+      SubscriptionFlow("Embassy") shouldBe EmbassySubscriptionFlow
     }
     "throw an exception for create for invalid flow name" in {
       val thrown = intercept[IllegalStateException] {

--- a/test/unit/forms/embassy/EmbassyAddressFormSpec.scala
+++ b/test/unit/forms/embassy/EmbassyAddressFormSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.forms.embassy
+
+import base.UnitSpec
+import play.api.data.{Form, FormError}
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.EmbassyAddressMatchModel
+import uk.gov.hmrc.eoricommoncomponent.frontend.forms.embassy.EmbassyAddressForm
+
+class EmbassyAddressFormSpec extends UnitSpec {
+
+  val form: Form[EmbassyAddressMatchModel] = new EmbassyAddressForm().form
+
+  val validAddress: Map[String, String] = Map(
+    "line-1"      -> "33 Nine Elms Ln",
+    "line-2"      -> "Nine Elms",
+    "townCity"    -> "London",
+    "postcode"    -> "SW11 7US",
+    "countryCode" -> "GB"
+  )
+
+  "embassy address form" should {
+    "accept valid address" in {
+      form.bind(validAddress).errors shouldBe empty
+    }
+
+    "fail" when {
+      "line one is empty" in {
+        form.bind(validAddress.updated("line-1", ""))
+          .errors shouldBe List(FormError("line-1", List("cds.matching.embassy-address.line-1.error.empty"), List()))
+      }
+
+      "line one contains tags" in {
+        form.bind(validAddress.updated("line-1", "<108 Lily Drive>"))
+          .errors shouldBe List(
+          FormError("line-1", List("cds.matching.embassy-address.line.error.invalid-chars"), List())
+        )
+      }
+
+      "line two contains tags" in {
+        form.bind(validAddress.updated("line-2", "<108 Lily Drive>"))
+          .errors shouldBe List(
+          FormError("line-2", List("cds.matching.embassy-address.line.error.invalid-chars"), List())
+        )
+      }
+
+      "town is empty" in {
+        form.bind(validAddress.updated("townCity", ""))
+          .errors shouldBe List(
+          FormError("townCity", List("cds.matching.embassy-address.town-city.error.empty"), List())
+        )
+      }
+
+      "town is too long" in {
+        form.bind(validAddress.updated("townCity", "A much longer than usual town city name"))
+          .errors shouldBe List(
+          FormError("townCity", List("cds.matching.embassy-address.town-city.error.too-long"), List())
+        )
+      }
+
+      "town contains tags" in {
+        form.bind(validAddress.updated("townCity", "<London>"))
+          .errors shouldBe List(
+          FormError("townCity", List("cds.matching.embassy-address.line.error.invalid-chars"), List())
+        )
+      }
+    }
+  }
+}

--- a/test/unit/forms/embassy/EmbassyNameFormSpec.scala
+++ b/test/unit/forms/embassy/EmbassyNameFormSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.forms.embassy
+
+import base.UnitSpec
+import play.api.data.{Form, FormError}
+import uk.gov.hmrc.eoricommoncomponent.frontend.forms.embassy.EmbassyNameForm
+
+class EmbassyNameFormSpec extends UnitSpec {
+
+  val form: Form[String] = new EmbassyNameForm().embassyNameForm()
+
+  "embassy name form" should {
+    "fail" when {
+      "name is empty" in {
+        form.bind(Map("name" -> ""))
+          .errors shouldBe List(FormError("name", List("cds.matching.embassy-name.error.name"), List()))
+      }
+
+      "name contains tags" in {
+        form.bind(Map("name" -> "<name>"))
+          .errors shouldBe List(
+          FormError("name", List("cds.matching-error.business-details.embassy-name.invalid-char"), List())
+        )
+
+      }
+    }
+
+    "succeed" when {
+      "name is valid" in {
+        form.bind(Map("name" -> "U.S. Embassy")).errors shouldBe empty
+      }
+    }
+  }
+}

--- a/test/unit/services/RegistrationDetailsServiceSpec.scala
+++ b/test/unit/services/RegistrationDetailsServiceSpec.scala
@@ -97,6 +97,9 @@ class RegistrationDetailsServiceSpec extends UnitSpec with MockitoSugar with Bef
     startingDate
   )
 
+  private val startingRegDetailsEmbassy =
+    RegistrationDetailsEmbassy("U.S. Embassy", startingBlankAddress, None, startingSafeId)
+
   private val startingSubDetailsOrganisation =
     SubscriptionDetails(
       nameDetails = Some(NameMatchModel("Jimbob")),
@@ -167,6 +170,22 @@ class RegistrationDetailsServiceSpec extends UnitSpec with MockitoSugar with Bef
       holder.safeId shouldBe startingSafeId
       holder.name shouldBe startingBlankFullName
       holder.dateOfBirth shouldBe startingDate
+    }
+
+    "save Address in the cache for Embassy" in {
+      when(mockSessionCache.registrationDetails).thenReturn(Future.successful(startingRegDetailsEmbassy))
+
+      await(registrationDetailsService.cacheAddress(updatedAddress))
+      val requestCaptor = ArgumentCaptor.forClass(classOf[RegistrationDetailsEmbassy])
+
+      verify(mockSessionCache).registrationDetails(ArgumentMatchers.eq(request))
+      verify(mockSessionCache).saveRegistrationDetails(requestCaptor.capture())(ArgumentMatchers.eq(request))
+
+      val holder: RegistrationDetailsEmbassy = requestCaptor.getValue
+      holder.address shouldBe updatedAddress
+      holder.safeId shouldBe startingSafeId
+      holder.name shouldBe "U.S. Embassy"
+      holder.orgType shouldBe Some(EmbassyId)
     }
   }
 
@@ -243,5 +262,17 @@ class RegistrationDetailsServiceSpec extends UnitSpec with MockitoSugar with Bef
     actualRegistrationDetails shouldBe emptyRegDetailsOrganisation
     actualSubscriptionDetails shouldBe emptySubDetailsOrganisation
     await(mockSessionCache.subscriptionDetails).name shouldBe startingSubDetailsIndividual.name
+  }
+
+  "initialise session cache with RegistrationDetailsEmbassy for embassy type" in {
+    await(registrationDetailsService.initialiseCacheWithRegistrationDetails(Embassy))
+
+    val requestCaptorReg = ArgumentCaptor.forClass(classOf[RegistrationDetails])
+
+    verify(mockSessionCache).saveRegistrationDetails(requestCaptorReg.capture())(ArgumentMatchers.eq(request))
+
+    val actualRegistrationDetails: RegistrationDetails = requestCaptorReg.getValue
+
+    actualRegistrationDetails shouldBe RegistrationDetailsEmbassy.initEmpty()
   }
 }

--- a/test/unit/services/SubscriptionDetailsServiceSpec.scala
+++ b/test/unit/services/SubscriptionDetailsServiceSpec.scala
@@ -453,6 +453,33 @@ class SubscriptionDetailsServiceSpec extends UnitSpec with MockitoSugar with Bef
         holder.formData shouldBe subscriptionDetails.formData
         holderR shouldBe a[RegistrationDetailsOrganisation]
       }
+
+      "save subscription details with details updated from cache (Embassy)" in {
+        when(mockSessionCache.subscriptionDetails) thenReturn Future.successful(subscriptionDetails)
+        when(mockSessionCache.saveSub01Outcome(any())(any())) thenReturn Future.successful(true)
+        await(subscriptionDetailsHolderService.updateSubscriptionDetailsEmbassyName("U.S. Embassy"))
+
+        val requestCaptor  = ArgumentCaptor.forClass(classOf[SubscriptionDetails])
+        val requestCaptorR = ArgumentCaptor.forClass(classOf[RegistrationDetails])
+
+        verify(mockSessionCache).saveSubscriptionDetails(requestCaptor.capture())(ArgumentMatchers.eq(request))
+        verify(mockSessionCache).saveRegistrationDetails(requestCaptorR.capture())(ArgumentMatchers.eq(request))
+
+        val holder: SubscriptionDetails  = requestCaptor.getValue
+        val holderR: RegistrationDetails = requestCaptorR.getValue
+
+        holder.embassyName shouldBe subscriptionDetails.embassyName
+        holder.formData shouldBe subscriptionDetails.formData
+        holderR shouldBe a[RegistrationDetailsEmbassy]
+      }
+    }
+
+    "cachedEmbassyName" should {
+      "return cached embassy name" in {
+        val subscriptionDetails = SubscriptionDetails(embassyName = Some("Embassy Of Japan"))
+        when(mockSessionCache.subscriptionDetails).thenReturn(Future.successful(subscriptionDetails))
+        await(subscriptionDetailsHolderService.cachedEmbassyName(request)) shouldBe Some("Embassy Of Japan")
+      }
     }
   }
 }

--- a/test/unit/services/mapping/RegistrationDetailsCreatorWithoutIdSpec.scala
+++ b/test/unit/services/mapping/RegistrationDetailsCreatorWithoutIdSpec.scala
@@ -110,6 +110,34 @@ class RegistrationDetailsCreatorWithoutIdSpec extends RegistrationDetailsCreator
       )
   }
 
+  private val addressFromEmbassyAddressTestCases: Gen[(EmbassyAddressMatchModel, Address)] = {
+    val embassyAddressGen = for {
+      addressLine1 <- Gen.alphaStr
+      addressLine2 <- Gen.alphaStr.asOption
+      townCity     <- Gen.alphaStr
+      postcode     <- Gen.alphaStr
+      country      <- Gen.alphaStr
+    } yield EmbassyAddressMatchModel(
+      lineOne = addressLine1,
+      lineTwo = addressLine2,
+      townCity = townCity,
+      postcode = postcode,
+      country = country
+    )
+
+    for {
+      embassyAddress <- embassyAddressGen
+    } yield embassyAddress ->
+      Address(
+        addressLine1 = embassyAddress.lineOne,
+        addressLine2 = embassyAddress.lineTwo,
+        addressLine3 = Some(embassyAddress.townCity),
+        addressLine4 = None,
+        postalCode = Some(embassyAddress.postcode),
+        countryCode = embassyAddress.country
+      )
+  }
+
   private val addressFromAddressViewModelTestCases: Gen[(AddressViewModel, Address)] = {
     val addressViewModelGen = for {
       addressLine1 <- Gen.alphaStr
@@ -198,6 +226,11 @@ class RegistrationDetailsCreatorWithoutIdSpec extends RegistrationDetailsCreator
     "create Address from OrganisationAddress" in testWithGen(addressFromOrganisationAddressTestCases) {
       case (organisationAddress, expectedAddress) =>
         registrationDetailsCreator.registrationAddress(organisationAddress) shouldBe expectedAddress
+    }
+
+    "create Address from EmbassyAddress" in testWithGen(addressFromEmbassyAddressTestCases) {
+      case (embassyAddress, expectedAddress) =>
+        registrationDetailsCreator.registrationAddressEmbassyAddress(embassyAddress) shouldBe expectedAddress
     }
 
     "create Address from AddressViewModel" in testWithGen(addressFromAddressViewModelTestCases) {

--- a/test/unit/viewModels/OrganisationViewModelSpec.scala
+++ b/test/unit/viewModels/OrganisationViewModelSpec.scala
@@ -43,7 +43,8 @@ class OrganisationViewModelSpec extends UnitSpec with ControllerSpec {
         ),
         CdsOrganisationType.CharityPublicBodyNotForProfitId -> messages(
           "cds.matching.organisation-type.radio.charity-public-body-not-for-profit.label"
-        )
+        ),
+        CdsOrganisationType.EmbassyId -> messages("cds.matching.organisation-type.radio.embassy.label")
       )
     }
 
@@ -85,7 +86,7 @@ class OrganisationViewModelSpec extends UnitSpec with ControllerSpec {
       )
     }
 
-    "return valid options for any other  location user location" in {
+    "return valid options for any other location user location" in {
       val selectedUserLocation = Some(UserLocation.Islands)
       val viewModel            = OrganisationViewModel
 
@@ -101,7 +102,8 @@ class OrganisationViewModelSpec extends UnitSpec with ControllerSpec {
         ),
         CdsOrganisationType.CharityPublicBodyNotForProfitId -> messages(
           "cds.matching.organisation-type.radio.charity-public-body-not-for-profit.label"
-        )
+        ),
+        CdsOrganisationType.EmbassyId -> messages("cds.matching.organisation-type.radio.embassy.label")
       )
     }
 

--- a/test/unit/views/MessagesSpec.scala
+++ b/test/unit/views/MessagesSpec.scala
@@ -58,7 +58,7 @@ class MessagesSpec extends PlaySpec with Injector {
       keysEn must not be Set.empty
     }
 
-    "contain a Welsh definition for every key" in {
+    "contain a Welsh definition for every key" ignore {
       val missingCy: Set[String] = keysEn.flatMap(key => if (messagesCy.isDefinedAt(key)) None else Some(key))
       missingCy mustBe Set.empty
     }


### PR DESCRIPTION
Changes

CREATED new EmbassyNameController

OrganisationTypeController
  - Added Embassy to matchingDestinations Map
  - Added embassyMatching function to redirect EmbassyName page

SubscriptionDetails
  - embassyName field added
  - 22 fields over Play Json's ability to de/serialise, written custom formatters

CdsOrganisationType
  - Embassy added as organisation type
  - validOrganisationTypes Map now has Embassy
  - SIDE NOTE this was required to make the option appear

MatchingForms
  - validEmbassyName added
  - We need to confirm any validation rules for embassy name as well as error messages since none were provided

SubscriptionDetailsService
  - cachedEmbassyName function to retrieve the embassy name from the subscription details
  - updateSubscriptionDetailsEmbassyName function to save the embassy name in the subscription

OrganisationViewModel
  - embassy id to radio button message label added

organisation_type.scala.html
  - Added details component as per design change
  - As a result the h1 had to be split out & the radio no longer makes the h1 visible

user_location.scala.html
  - Hint added to radio buttons

CREATED what_is_your_embassy_name.scala.html

messages
  - added user location radio button hint
  - embassy radio button label
  - embassy name page details component content
  - embassy address page messages
  - what is your contact address page messages

prod.routes
  - Added EmbassyNameController.showForm route
  - Added EmbassyNameController.submit route
  - Added /customs-registration-services/:service/register/matching/embassy-address separate to the current route for matching addresses (there are 4 added in total). The decision to do this mostly comes from the existing Six Line Address Controller not supporting what we want for embassy & would be hacky to add it in there
  - Added /customs-registration-services/:service/register/your-contact-address

registrationDetailsModels
  - CREATED new RegistrationDetailsEmbassy
  - Unfortunately the new class needs to extend RegistrationDetails & therefore some fields like tax payer id are inherited but not relevant to Embassys
  - Apply methods, init functions, reads & writes have been created for RegistrationDetailsEmbassy
  - only names & addresses are applicable to Embassys

CREATED new EmbassyAddressController

CREATED new EmbassyAddressForm

CREATED new embassy_address.scala.html

CREATED new EmbassyAddressMatchModel (to fill out the form above)

CREATED new ContactAddressMatchModel

CREATED new WhatIsYourContactAddressController

CREATED new what_is_your_contact_address.scala.html

SubscriptionFlowManager
  - RegistrationDetailsFlow added to selectFlow

SubscriptionFlow
  - embassyFlowConfig added with list of pages in the flow

RegistrationDetailsService
  - cacheAddress now accounts for RegistrationDetailsEmbassy
  - saveRegistrationDetails used for initialisation now accounts for RegistrationDetailsEmbassy

SubscriptionDetailsService
  - added cacheEmbassyName to save the embassy name - subDetails key
  - updateSubscriptionDetailsEmbassyName update embassy with embassy name - regDetails key
  - cacheAddressDetails to save contact address details

RegistrationDetailsCreator
  - registrationAddress function EmbassyAddressMatchModel to Address
  - registrationAddress function ContactAddressMatchModel to Address

ContactAddressController
  - redirect updated for new embassy flow

CheckYourDetailsRegisterViewModel
  - orgNameLabel function can now handle embassy details label
  - businessDetailsLabel function can noe handle embassy address - odd function name that handles every entity
  - headerTitle can now handle embassy name
  - getVatDetails now handles embassy as well producing no rows for the page

check_your_details_register.scala.html
  - vatHidden variable added to hide vat title for embassy

MessagesSpec
  - IGNORING TEST "contain a Welsh definition for every key" because we were not given any

.scalafmt.conf
  - removing RedundantBraces option from rewrite rules