### PR TITLE
DDCYLS-6064

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/SubscriptionDetailsService.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/SubscriptionDetailsService.scala
@@ -202,6 +202,7 @@ class SubscriptionDetailsService @Inject() (
 
   def updateSubscriptionDetailsOrganisation(implicit request: Request[_]): Future[Unit] =
     for {
+      _ <- sessionCache.saveRegistrationDetails(RegistrationDetailsOrganisation())
       _ <- updateSubscriptionDetails
     } yield ()
 


### PR DESCRIPTION
It turns out that this line of code that we removed, because we couldn't ascertain it's original purpose was there to clear the contents of the database if the person entered a UTR & went back on themselves to state they didn't have one. What a hack.