### PR TITLE
DDCYLS-6067

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/ContactAddressController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/ContactAddressController.scala
@@ -23,7 +23,9 @@ import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes._
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.CdsOrganisationType.{
   CharityPublicBodyNotForProfit,
   Embassy,
-  Partnership
+  Individual,
+  Partnership,
+  SoleTrader
 }
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.ContactAddressSubscriptionFlowPageGetEori
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.{LoggedInUserWithEnrolments, YesNo}
@@ -144,7 +146,7 @@ class ContactAddressController @Inject() (
       if (
         optOrgType.contains(Embassy) || optOrgType.contains(CharityPublicBodyNotForProfit) || optOrgType.contains(
           Partnership
-        )
+        ) || optOrgType.contains(Individual) || optOrgType.contains(SoleTrader)
       ) {
         if (yesNoAnswer.isYes) {
           Redirect(DetermineReviewPageController.determineRoute(service))

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/NameDobController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/NameDobController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.eoricommoncomponent.frontend.controllers
 import play.api.mvc._
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.auth.AuthAction
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
-import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.SubscriptionDetails
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.{FormData, SubscriptionDetails}
 import uk.gov.hmrc.eoricommoncomponent.frontend.forms.MatchingForms.enterNameDobForm
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 import uk.gov.hmrc.eoricommoncomponent.frontend.services.cache.{RequestSessionData, SessionCache}
@@ -56,14 +56,21 @@ class NameDobController @Inject() (
       )
     }
 
-  private def submitNewDetails(formData: NameDobMatchModel, service: Service)(implicit
-    request: Request[_]
-  ): Future[Result] =
-    cdsFrontendDataCache.saveSubscriptionDetails(SubscriptionDetails(nameDobDetails = Some(formData))).map { _ =>
+  private def submitNewDetails(nameDob: NameDobMatchModel, service: Service)(implicit
+    request: Request[AnyContent]
+  ): Future[Result] = {
+    cdsFrontendDataCache.saveSubscriptionDetails(
+      SubscriptionDetails(
+        nameDobDetails = Some(nameDob),
+        formData = FormData(organisationType = requestSessionData.userSelectedOrganisationType)
+      )
+    ).map { _ =>
       Redirect(
-        uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes.HowCanWeIdentifyYouController
-          .createForm(service)
+        uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes.WhatIsYourOrganisationsAddressController.showForm(
+          service
+        )
       )
     }
+  }
 
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/VatDetailsController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/VatDetailsController.scala
@@ -64,7 +64,15 @@ class VatDetailsController @Inject() (
         sessionCacheService.individualAndSoleTraderRouter(
           user.groupId.getOrElse(throw new Exception("GroupId does not exists")),
           service,
-          Ok(vatDetailsView(vatDetailsForm, isInReviewMode = false, userLocation, service))
+          Ok(
+            vatDetailsView(
+              vatDetailsForm,
+              isInReviewMode = false,
+              userLocation,
+              requestSessionData.isIndividualOrSoleTrader,
+              service
+            )
+          )
         )
     }
 
@@ -75,8 +83,25 @@ class VatDetailsController @Inject() (
           requestSessionData.selectedUserLocation.getOrElse(throw DataUnavailableException("User Location not set"))
         subscriptionBusinessService.getCachedUkVatDetails.map {
           case Some(vatDetails) =>
-            Ok(vatDetailsView(vatDetailsForm.fill(vatDetails), isInReviewMode = true, userLocation, service))
-          case None => Ok(vatDetailsView(vatDetailsForm, isInReviewMode = true, userLocation, service))
+            Ok(
+              vatDetailsView(
+                vatDetailsForm.fill(vatDetails),
+                isInReviewMode = true,
+                userLocation,
+                requestSessionData.isIndividualOrSoleTrader,
+                service
+              )
+            )
+          case None =>
+            Ok(
+              vatDetailsView(
+                vatDetailsForm,
+                isInReviewMode = true,
+                userLocation,
+                requestSessionData.isIndividualOrSoleTrader,
+                service
+              )
+            )
         }.flatMap(
           sessionCacheService.individualAndSoleTraderRouter(
             user.groupId.getOrElse(throw new Exception("GroupId does not exists")),
@@ -92,7 +117,17 @@ class VatDetailsController @Inject() (
         requestSessionData.selectedUserLocation.getOrElse(throw DataUnavailableException("User Location not set"))
       vatDetailsForm.bindFromRequest().fold(
         formWithErrors =>
-          Future.successful(BadRequest(vatDetailsView(formWithErrors, isInReviewMode, userLocation, service))),
+          Future.successful(
+            BadRequest(
+              vatDetailsView(
+                formWithErrors,
+                isInReviewMode,
+                userLocation,
+                requestSessionData.isIndividualOrSoleTrader,
+                service
+              )
+            )
+          ),
         formData => lookupVatDetails(formData, isInReviewMode, service)
       )
     }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/WhatIsYourOrganisationsAddressController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/WhatIsYourOrganisationsAddressController.scala
@@ -18,11 +18,12 @@ package uk.gov.hmrc.eoricommoncomponent.frontend.controllers
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Request}
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.auth.AuthAction
-import uk.gov.hmrc.eoricommoncomponent.frontend.domain.CdsOrganisationType.Partnership
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.CdsOrganisationType.{Individual, Partnership, SoleTrader}
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.Address
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.registration.UserLocation
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.{
   CharityPublicBodySubscriptionNoUtrFlow,
+  IndividualSoleTraderFlowIom,
   PartnershipSubscriptionFlowIom,
   SubscriptionFlow
 }
@@ -117,6 +118,8 @@ class WhatIsYourOrganisationsAddressController @Inject() (
   )(implicit request: Request[AnyContent]): SubscriptionFlow = {
     (requestSessionData.selectedUserLocation, cdsOrganisationType) match {
       case (Some(UserLocation.Iom), Partnership) => PartnershipSubscriptionFlowIom
+      case (Some(UserLocation.Iom), Individual)  => IndividualSoleTraderFlowIom
+      case (Some(UserLocation.Iom), SoleTrader)  => IndividualSoleTraderFlowIom
       case _                                     => CharityPublicBodySubscriptionNoUtrFlow
     }
   }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/subscription/SubscriptionFlow.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/subscription/SubscriptionFlow.scala
@@ -44,6 +44,17 @@ object SubscriptionFlows {
     )
   )
 
+  private val individualSoleTraderFlowIomConfig = createFlowConfig(
+    List(
+      SicCodeSubscriptionFlowPage,
+      EoriConsentSubscriptionFlowPage,
+      VatRegisteredSubscriptionFlowPage,
+      YourVatDetailsSubscriptionFlowPage,
+      ContactDetailsSubscriptionFlowPageGetEori,
+      ContactAddressSubscriptionFlowPageGetEori
+    )
+  )
+
   private val corporateFlowConfig = createFlowConfig(
     List(
       DateOfEstablishmentSubscriptionFlowPage,
@@ -175,7 +186,8 @@ object SubscriptionFlows {
     CharityPublicBodySubscriptionNoUtrFlow    -> charityPublicBodySubscriptionNoUtrFlowConfig,
     CharityPublicBodySubscriptionFlowIom      -> charityPublicBodyNotForProfitFlowIomConfig,
     CharityPublicBodySubscriptionNoUtrFlowIom -> charityPublicBodySubscriptionNoUtrFlowIomConfig,
-    PartnershipSubscriptionFlowIom            -> partnershipFlowIomConfig
+    PartnershipSubscriptionFlowIom            -> partnershipFlowIomConfig,
+    IndividualSoleTraderFlowIom               -> individualSoleTraderFlowIomConfig
   )
 
   private def createFlowConfig(flowStepList: List[SubscriptionPage]): SubscriptionFlowConfig =
@@ -212,6 +224,8 @@ case object ThirdCountryIndividualSubscriptionFlow
     extends SubscriptionFlow(ThirdCountryIndividual.id, isIndividualFlow = true)
 
 case object SoleTraderSubscriptionFlow extends SubscriptionFlow(SoleTrader.id, isIndividualFlow = true)
+
+case object IndividualSoleTraderFlowIom extends SubscriptionFlow("IndividualSoleTraderIom", isIndividualFlow = true)
 
 case object CharityPublicBodySubscriptionFlow extends SubscriptionFlow("CharityPublicBody", isIndividualFlow = false)
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/viewModels/CheckYourDetailsRegisterViewModel.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/viewModels/CheckYourDetailsRegisterViewModel.scala
@@ -190,7 +190,7 @@ class CheckYourDetailsRegisterConstructor @Inject() (
 
       for {
         providedDetailsList <- providedDetails
-        vatDetails             = getVatDetails(isIndividual, isEmbassy, subscription)
+        vatDetails             = getVatDetails(isEmbassy, subscription)
         providedContactDetails = getProvidedContactDetails(subscription, service)
       } yield CheckYourDetailsRegisterViewModel(headerTitle, providedDetailsList, vatDetails, providedContactDetails)
     }
@@ -421,10 +421,10 @@ class CheckYourDetailsRegisterConstructor @Inject() (
     )
   }
 
-  private def getVatDetails(isIndividual: Boolean, isEmbassy: Boolean, subscription: SubscriptionDetails)(implicit
+  private def getVatDetails(isEmbassy: Boolean, subscription: SubscriptionDetails)(implicit
     messages: Messages
   ): Seq[SummaryListRow] =
-    if (!isIndividual && !isEmbassy) {
+    if (!isEmbassy) {
       val dateOfReg = for {
         resp <- subscription.vatControlListResponse
         date <- resp.dateOfReg

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/viewModels/VatRegisteredUkViewModel.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/viewModels/VatRegisteredUkViewModel.scala
@@ -30,13 +30,17 @@ object VatRegisteredUkViewModel {
 
   def titleAndHeadingLabel(isIndividualSubscriptionFlow: Boolean, isPartnership: Boolean, userLocation: UserLocation)(
     implicit messages: Messages
-  ): String =
-    if (isIndividualSubscriptionFlow) messages("cds.subscription.vat-question-uk.individual")
+  ): String = {
+    if (isIndividualSubscriptionFlow && userLocation == Iom)
+      messages("cds.subscription.vat-registered.individual.title-and-heading")
+    else if (isIndividualSubscriptionFlow && userLocation != Iom)
+      messages("cds.subscription.vat-question-uk.individual")
     else if (isPartnership && userLocation != Iom)
       messages("cds.subscription.vat-registered-uk.partnership.title-and-heading")
     else if (isPartnership && userLocation == Iom)
       messages("cds.subscription.vat-registered.partnership.title-and-heading")
     else if (userLocation == Iom) messages("cds.subscription.vat-registered.title-and-heading")
     else messages("cds.subscription.vat-registered-uk.title-and-heading")
+  }
 
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/check_your_details_register.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/check_your_details_register.scala.html
@@ -31,9 +31,8 @@
 )(implicit request: Request[_], messages: Messages)
 
 
-@isIndividual = @{
-    cdsOrgType.contains(CdsOrganisationType.Individual) ||
-    cdsOrgType.contains(CdsOrganisationType.EUIndividual) || cdsOrgType.contains(CdsOrganisationType.ThirdCountryIndividual)
+@isEmbassy = @{
+    cdsOrgType.contains(CdsOrganisationType.Embassy)
 }
 
 @vatHidden = @{
@@ -49,7 +48,7 @@
             @govukSummaryList(viewModel.providedDetails)
         </div>
 
-        @if(!isIndividual){
+        @if(!isEmbassy){
 
         <div>
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/vat_details.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/vat_details.scala.html
@@ -30,7 +30,7 @@
 appConfig:AppConfig, h1: helpers.h1, p: helpers.paragraph, link: helpers.linkWithPreTextAndPostText)
 
 
-@(vatForm: Form[VatDetails], isInReviewMode: Boolean, userLocation: UserLocation, service: Service)(implicit request: Request[_], messages: Messages)
+@(vatForm: Form[VatDetails], isInReviewMode: Boolean, userLocation: UserLocation, isIndividualOrSoleTrader: Boolean, service: Service)(implicit request: Request[_], messages: Messages)
 
 @heading = @{
     if(userLocation == Iom) {
@@ -42,7 +42,11 @@ appConfig:AppConfig, h1: helpers.h1, p: helpers.paragraph, link: helpers.linkWit
 
 @postcodeLabel = @{
     if(userLocation == Iom) {
-        messages("cds.subscription.vat-details.postcode")
+        if(isIndividualOrSoleTrader) {
+            messages("cds.subscription.vat-details.individual-sole-trader.postcode")
+        } else {
+            messages("cds.subscription.vat-details.postcode")
+        }
     } else {
         messages("cds.subscription.vat-details.uk.postcode")
     }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/what_is_your_organisations_address.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/what_is_your_organisations_address.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes
-@import uk.gov.hmrc.eoricommoncomponent.frontend.domain.CdsOrganisationType.PartnershipId
+@import uk.gov.hmrc.eoricommoncomponent.frontend.domain.CdsOrganisationType.{IndividualId, PartnershipId, SoleTraderId}
 @import uk.gov.hmrc.eoricommoncomponent.frontend.domain.ContactAddressMatchModel
 @import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 @import uk.gov.hmrc.eoricommoncomponent.frontend.services.countries._
@@ -45,11 +45,13 @@
 
 @title = @{
     if(cdsOrgType==PartnershipId) messages("cds.your-partnership-address.title")
+    else if(cdsOrgType==IndividualId || cdsOrgType==SoleTraderId) messages("cds.your-individual-sole-trader-address.title")
     else messages("cds.your-organisation-address.title")
 }
 
 @header = @{
     if(cdsOrgType==PartnershipId) messages("cds.your-partnership-address.header")
+    else if(cdsOrgType==IndividualId || cdsOrgType==SoleTraderId) messages("cds.your-individual-sole-trader-address.header")
     else messages("cds.your-organisation-address.header")
 }
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -400,7 +400,7 @@ cds.subscription.contact-details.form-error.email.wrong-format=Enter an email ad
 
 cds.email-confirmed.para.get-eori=You can continue with your application to get an EORI number.
 
-subscription.check-your-details.full-name.label=Full name
+subscription.check-your-details.full-name.label=Registered first name and last name
 subscription.check-your-details.date-of-birth.label=Date of birth
 cds.organisation.name.label=Organisation name
 cds.company.name.label=Company name
@@ -893,6 +893,7 @@ cds.subscription.vat-details.intro-text.link=Sign in to your VAT online account 
 cds.subscription.vat-details.intro-text.link.text = to view your VAT certificate.
 cds.subscription.vat-details.uk.postcode=What is the UK postcode where your organisation is registered for VAT?
 cds.subscription.vat-details.postcode=What is the postcode where your organisation is registered for VAT?
+cds.subscription.vat-details.individual-sole-trader.postcode=What is the postcode where you are registered for VAT?
 cds.subscription.vat-details.vat-number=What is your VAT registration number?
 cds.subscription.vat-details.vat-number.hint-text = This is 9 numbers, sometimes with ‘GB’ at the start, for example 123456789 or GB123456789.
 
@@ -1028,6 +1029,7 @@ cds.subscription.sic.description.charity-public-body-not-for-profit.para4.bullet
 cds.subscription.sic.description.para2=Enter a 5-digit SIC code for your organisation
 cds.subscription.sic.description.para2.company = What is the company’s SIC code?
 cds.subscription.sic.description.para2.sole-trader = What is your SIC code?
+cds.subscription.sic.description.para2.individual = What is your SIC code?
 cds.subscription.sic.description.para2.partnership = What is the partnership’s SIC code?
 cds.subscription.sic.description.para2.limited-liability-partnership = What is the partnership’s SIC code?
 cds.subscription.sic.description.para2.charity-public-body-not-for-profit = What is your SIC code?
@@ -1239,6 +1241,7 @@ cds.subscription.vat-registered.title-and-heading=Is your organisation VAT regis
 cds.subscription.vat-registered-uk.title-and-heading=Is your organisation VAT registered in the UK?
 cds.subscription.vat-registered-uk.partnership.title-and-heading=Is your partnership VAT registered in the UK?
 cds.subscription.vat-registered.partnership.title-and-heading=Is your partnership VAT registered?
+cds.subscription.vat-registered.individual.title-and-heading=Are you VAT registered?
 cds.subscription.vat-registered-uk.page-error.yes-no-answer=Confirm whether the organisation is VAT registered in the UK
 cds.subscription.vat-group.title-and-heading=Is your organisation part of a VAT group in the UK?
 cds.subscription.vat-verification-option.title-and-heading=What do you want to use to verify your identity?
@@ -1619,7 +1622,7 @@ cds.navigation.subscribe=Subscribe
 
 subscription.check-your-email.no=No, I need to change this email address
 
-cds.form.contact-details=Your address
+cds.form.contact-details=Registered address
 
 cds.error.field.hint=Error
 
@@ -2145,8 +2148,10 @@ cds.your-contact-address.postcode=Postcode
 #Your Organisation Address
 cds.your-organisation-address.title=What is your organisation’s address?
 cds.your-partnership-address.title=What is your registered partnership address?
+cds.your-individual-sole-trader-address.title=What is your address?
 cds.your-organisation-address.header=What is your organisation’s address?
 cds.your-partnership-address.header=What is your registered partnership address?
+cds.your-individual-sole-trader-address.header=What is your address?
 cds.your-organisation-address.line-1=Address line 1
 cds.your-organisation-address.line-2=Address line 2 (optional)
 cds.your-organisation-address.town-city=Town or city

--- a/test/unit/controllers/CheckYourDetailsRegisterControllerSpec.scala
+++ b/test/unit/controllers/CheckYourDetailsRegisterControllerSpec.scala
@@ -141,7 +141,10 @@ class CheckYourDetailsRegisterControllerSpec
 
       showForm(userSelectedOrgType = SoleTrader) { result =>
         val page = CdsPage(contentAsString(result))
-        page.getSummaryListValue(RegistrationReviewPage.SummaryListRowXPath, "Full name") shouldBe
+        page.getSummaryListValue(
+          RegistrationReviewPage.SummaryListRowXPath,
+          "Registered first name and last name"
+        ) shouldBe
           strim("""
                 |John
                 |Doe
@@ -166,7 +169,10 @@ class CheckYourDetailsRegisterControllerSpec
 
       showForm(userSelectedOrgType = SoleTrader) { result =>
         val page = CdsPage(contentAsString(result))
-        page.getSummaryListValue(RegistrationReviewPage.SummaryListRowXPath, "Full name") shouldBe
+        page.getSummaryListValue(
+          RegistrationReviewPage.SummaryListRowXPath,
+          "Registered first name and last name"
+        ) shouldBe
           strim("""
                 |John
                 |Doe
@@ -174,12 +180,12 @@ class CheckYourDetailsRegisterControllerSpec
 
         page.getSummaryListLink(
           RegistrationReviewPage.SummaryListRowXPath,
-          "Full name",
+          "Registered first name and last name",
           "Change"
-        ) shouldBe RegistrationReviewPage.changeAnswerText("Full name")
+        ) shouldBe RegistrationReviewPage.changeAnswerText("Registered first name and last name")
         page.getSummaryListHref(
           RegistrationReviewPage.SummaryListRowXPath,
-          "Full name",
+          "Registered first name and last name",
           "Change"
         ) shouldBe "/customs-registration-services/atar/register/matching/row-name-date-of-birth/sole-trader/review"
 
@@ -398,7 +404,7 @@ class CheckYourDetailsRegisterControllerSpec
         showForm(userSelectedOrgType = organisationType) { result =>
           val page = CdsPage(contentAsString(result))
 
-          page.summaryListElementPresent(RegistrationReviewPage.SummaryListRowXPath, "Your address") shouldBe true
+          page.summaryListElementPresent(RegistrationReviewPage.SummaryListRowXPath, "Registered address") shouldBe true
         }
       }
     }
@@ -775,7 +781,7 @@ class CheckYourDetailsRegisterControllerSpec
     showForm(userSelectedOrgType = Individual, isIndividualSubscriptionFlow = true) { result =>
       val page: CdsPage = CdsPage(contentAsString(result))
 
-      page.h2() should startWith("Your details Contact details Declaration Support links")
+      page.h2() should startWith("Your details VAT details Contact details Declaration Support links")
 
       page.summaryListElementPresent(
         RegistrationReviewPage.SummaryListRowXPath,

--- a/test/unit/controllers/NameDobControllerSpec.scala
+++ b/test/unit/controllers/NameDobControllerSpec.scala
@@ -230,7 +230,7 @@ class NameDobControllerSpec extends ControllerSpec with BeforeAndAfterEach with 
       submitForm(ValidRequest, defaultOrganisationType) { result =>
         status(result) shouldBe SEE_OTHER
         header("Location", result).value should endWith(
-          "/customs-registration-services/atar/register/matching/chooseid"
+          "/customs-registration-services/atar/register/your-organisation-address"
         )
       }
     }

--- a/test/unit/views/VatDetailsUkSpec.scala
+++ b/test/unit/views/VatDetailsUkSpec.scala
@@ -49,6 +49,10 @@ class VatDetailsUkSpec extends ViewSpec {
   }
 
   private lazy val doc: Document =
-    Jsoup.parse(contentAsString(view(form, isInReviewMode = false, UserLocation.Uk, atarService)))
+    Jsoup.parse(
+      contentAsString(
+        view(form, isInReviewMode = false, UserLocation.Uk, isIndividualOrSoleTrader = false, atarService)
+      )
+    )
 
 }

--- a/test/unit/views/VatDetailsViewSpec.scala
+++ b/test/unit/views/VatDetailsViewSpec.scala
@@ -82,12 +82,12 @@ class VatDetailsViewSpec extends ViewSpec {
   }
 
   private lazy val doc: Document = {
-    val result = view(form, isInReviewMode = false, UserLocation.Uk, atarService)
+    val result = view(form, isInReviewMode = false, UserLocation.Uk, isIndividualOrSoleTrader = false, atarService)
     Jsoup.parse(contentAsString(result))
   }
 
   private lazy val iomDoc: Document = {
-    val result = view(form, isInReviewMode = false, UserLocation.Iom, atarService)
+    val result = view(form, isInReviewMode = false, UserLocation.Iom, isIndividualOrSoleTrader = false, atarService)
     Jsoup.parse(contentAsString(result))
   }
 


### PR DESCRIPTION
ISLE OF MAN INDIVIDUAL & SOLE TRADER

ContactAddressController
 - now redirects to WhatIsYourContactAddressController for Individual & Sole Trader

NameDobController
- Now redirects to WhatIsYourOrganisationsAddressController rather than HowCanWeIdentifyYouController

VatDetailsController
 - Now passes in whether the entity is an Individual or a Sole Trader to the view (for postcode label purposes)

WhatIsYourOrganisationsAddressController
 - redirectFlowLocation now accounts for both the Individual & Sole Trader flow for Isle Of Man.

SubscriptionFlow
 - NEW individualSoleTraderFlowIomConfig containing the page flow for Individual & Sole Trader for Isle Of Man
 - NEW IndividualSoleTraderFlowIom that maps to the above individualSoleTraderFlowIomConfig

VatRegisteredUkViewModel
 - Now accounts for Individual & Sole Trader for Isle Of Man when selecting the title & heading

CheckYourDetailsRegisterViewModel
 - getVatDetails function no longer hides the VAT Details section for Individuals

check_your_details_register.scala.html
 - no longer hides VAT details from Individuals

vat_details.scala.html
 - Now takes isIndividualOrSoleTrader boolean
 - postcode label changes when the entity is an Individual or Sole Trader

what_is_your_organisations_address.scala.html
 - title & header now take into account the Individual & Sole Trader entity types to select the right title & header

messages.en
 - Added title & headers for Individual & Sole Trader, mostly for VAT pages.

DDCYLS-6067 another check in