### PR TITLE
DDCYLS-6067

### DIFF
--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/VatRegisteredUkController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/VatRegisteredUkController.scala
@@ -68,9 +68,9 @@ class VatRegisteredUkController @Inject() (
               Ok(
                 vatRegisteredUkView(
                   isInReviewMode = false,
-                  vatRegisteredUkYesNoAnswerForm(requestSessionData.isPartnershipOrLLP),
+                  vatRegisteredUkYesNoAnswerForm(requestSessionData.isPartnership),
                   isIndividual,
-                  requestSessionData.isPartnershipOrLLP,
+                  requestSessionData.isPartnership,
                   location,
                   service
                 )
@@ -100,9 +100,9 @@ class VatRegisteredUkController @Inject() (
               Ok(
                 vatRegisteredUkView(
                   isInReviewMode = true,
-                  vatRegisteredUkYesNoAnswerForm(requestSessionData.isPartnershipOrLLP).fill(yesNo),
+                  vatRegisteredUkYesNoAnswerForm(requestSessionData.isPartnership).fill(yesNo),
                   individual,
-                  requestSessionData.isPartnershipOrLLP,
+                  requestSessionData.isPartnership,
                   location,
                   service
                 )
@@ -116,7 +116,7 @@ class VatRegisteredUkController @Inject() (
 
   def submit(isInReviewMode: Boolean, service: Service): Action[AnyContent] =
     authAction.enrolledUserWithSessionAction(service) { implicit request => _: LoggedInUserWithEnrolments =>
-      vatRegisteredUkYesNoAnswerForm(requestSessionData.isPartnershipOrLLP)
+      vatRegisteredUkYesNoAnswerForm(requestSessionData.isPartnership)
         .bindFromRequest()
         .fold(
           formWithErrors =>
@@ -131,7 +131,7 @@ class VatRegisteredUkController @Inject() (
                       isInReviewMode,
                       formWithErrors,
                       individual,
-                      requestSessionData.isPartnershipOrLLP,
+                      requestSessionData.isPartnership,
                       location,
                       service
                     )

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/WhatIsYourOrgNameController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/WhatIsYourOrgNameController.scala
@@ -19,7 +19,11 @@ package uk.gov.hmrc.eoricommoncomponent.frontend.controllers
 import play.api.mvc._
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.auth.AuthAction
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes._
-import uk.gov.hmrc.eoricommoncomponent.frontend.domain.CdsOrganisationType.PartnershipId
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.CdsOrganisationType.{
+  CompanyId,
+  LimitedLiabilityPartnershipId,
+  PartnershipId
+}
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain._
 import uk.gov.hmrc.eoricommoncomponent.frontend.forms.MatchingForms.organisationNameForm
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
@@ -72,7 +76,9 @@ class WhatIsYourOrgNameController @Inject() (
     subscriptionDetailsService.cacheNameDetails(NameOrganisationMatchModel(formData.name)) flatMap { _ =>
       if (!isInReviewMode)
         subscriptionDetailsService.updateSubscriptionDetailsOrgName(formData.name).map { _ =>
-          if (organisationType == PartnershipId) {
+          if (
+            organisationType == PartnershipId || organisationType == CompanyId || organisationType == LimitedLiabilityPartnershipId
+          ) {
             Redirect(WhatIsYourOrganisationsAddressController.showForm(service))
           } else {
             Redirect(DoYouHaveAUtrNumberController.form(organisationType, service, isInReviewMode = false))

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/WhatIsYourOrganisationsAddressController.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/controllers/WhatIsYourOrganisationsAddressController.scala
@@ -18,11 +18,18 @@ package uk.gov.hmrc.eoricommoncomponent.frontend.controllers
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Request}
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.auth.AuthAction
-import uk.gov.hmrc.eoricommoncomponent.frontend.domain.CdsOrganisationType.{Individual, Partnership, SoleTrader}
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.CdsOrganisationType.{
+  Company,
+  Individual,
+  LimitedLiabilityPartnership,
+  Partnership,
+  SoleTrader
+}
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.messaging.Address
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.registration.UserLocation
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.{
   CharityPublicBodySubscriptionNoUtrFlow,
+  CompanyLlpFlowIom,
   IndividualSoleTraderFlowIom,
   PartnershipSubscriptionFlowIom,
   SubscriptionFlow
@@ -117,10 +124,12 @@ class WhatIsYourOrganisationsAddressController @Inject() (
     cdsOrganisationType: CdsOrganisationType
   )(implicit request: Request[AnyContent]): SubscriptionFlow = {
     (requestSessionData.selectedUserLocation, cdsOrganisationType) match {
-      case (Some(UserLocation.Iom), Partnership) => PartnershipSubscriptionFlowIom
-      case (Some(UserLocation.Iom), Individual)  => IndividualSoleTraderFlowIom
-      case (Some(UserLocation.Iom), SoleTrader)  => IndividualSoleTraderFlowIom
-      case _                                     => CharityPublicBodySubscriptionNoUtrFlow
+      case (Some(UserLocation.Iom), Partnership)                 => PartnershipSubscriptionFlowIom
+      case (Some(UserLocation.Iom), Individual)                  => IndividualSoleTraderFlowIom
+      case (Some(UserLocation.Iom), SoleTrader)                  => IndividualSoleTraderFlowIom
+      case (Some(UserLocation.Iom), Company)                     => CompanyLlpFlowIom
+      case (Some(UserLocation.Iom), LimitedLiabilityPartnership) => CompanyLlpFlowIom
+      case _                                                     => CharityPublicBodySubscriptionNoUtrFlow
     }
   }
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/subscription/SubscriptionFlow.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/domain/subscription/SubscriptionFlow.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription
 import play.api.Logging
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.SubscriptionFlowConfig
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.CdsOrganisationType._
-import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.SubscriptionFlows.charityPublicBodySubscriptionNoUtrFlowIomConfig
 import uk.gov.hmrc.eoricommoncomponent.frontend.models.Service
 
 object SubscriptionFlows {
@@ -173,6 +172,18 @@ object SubscriptionFlows {
     )
   )
 
+  private val companyLlpFlowIomConfig = createFlowConfig(
+    List(
+      DateOfEstablishmentSubscriptionFlowPage,
+      SicCodeSubscriptionFlowPage,
+      EoriConsentSubscriptionFlowPage,
+      VatRegisteredSubscriptionFlowPage,
+      YourVatDetailsSubscriptionFlowPage,
+      ContactDetailsSubscriptionFlowPageGetEori,
+      ContactAddressSubscriptionFlowPageGetEori
+    )
+  )
+
   val flows: Map[SubscriptionFlow, SubscriptionFlowConfig] = Map(
     OrganisationSubscriptionFlow              -> corporateFlowConfig,
     PartnershipSubscriptionFlow               -> partnershipFlowConfig,
@@ -187,7 +198,8 @@ object SubscriptionFlows {
     CharityPublicBodySubscriptionFlowIom      -> charityPublicBodyNotForProfitFlowIomConfig,
     CharityPublicBodySubscriptionNoUtrFlowIom -> charityPublicBodySubscriptionNoUtrFlowIomConfig,
     PartnershipSubscriptionFlowIom            -> partnershipFlowIomConfig,
-    IndividualSoleTraderFlowIom               -> individualSoleTraderFlowIomConfig
+    IndividualSoleTraderFlowIom               -> individualSoleTraderFlowIomConfig,
+    CompanyLlpFlowIom                         -> companyLlpFlowIomConfig
   )
 
   private def createFlowConfig(flowStepList: List[SubscriptionPage]): SubscriptionFlowConfig =
@@ -237,6 +249,8 @@ case object CharityPublicBodySubscriptionNoUtrFlow
 
 case object CharityPublicBodySubscriptionNoUtrFlowIom
     extends SubscriptionFlow("CharityPublicBodyNoUtrIom", isIndividualFlow = false)
+
+case object CompanyLlpFlowIom extends SubscriptionFlow("CompanyLlpIom", isIndividualFlow = false)
 
 object SubscriptionFlow extends Logging {
 

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/cache/RequestSessionData.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/services/cache/RequestSessionData.scala
@@ -105,11 +105,6 @@ class RequestSessionData @Inject() (audit: Auditable) {
   def existingSessionWithUserLocationAdded(existingSession: Session, userLocation: String): Session =
     existingSession + (RequestSessionDataKeys.selectedUserLocation -> userLocation)
 
-  def isPartnershipOrLLP(implicit request: Request[AnyContent]): Boolean = userSelectedOrganisationType.fold(false) {
-    orgType =>
-      orgType == CdsOrganisationType.Partnership || orgType == CdsOrganisationType.LimitedLiabilityPartnership
-  }
-
   def isPartnership(implicit request: Request[AnyContent]): Boolean = userSelectedOrganisationType.fold(false) {
     orgType => orgType == CdsOrganisationType.Partnership
   }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/viewModels/CheckYourDetailsRegisterViewModel.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/viewModels/CheckYourDetailsRegisterViewModel.scala
@@ -150,7 +150,7 @@ class CheckYourDetailsRegisterConstructor @Inject() (
     } yield {
 
       val cdsOrgType    = requestSessionData.userSelectedOrganisationType
-      val isPartnership = requestSessionData.isPartnershipOrLLP
+      val isPartnership = cdsOrgType.contains(CdsOrganisationType.Partnership)
 
       val isIndividual = cdsOrgType.contains(CdsOrganisationType.Individual) ||
         cdsOrgType.contains(CdsOrganisationType.EUIndividual) ||
@@ -175,7 +175,7 @@ class CheckYourDetailsRegisterConstructor @Inject() (
         else if (isEmbassy)
           messages("cds.form.check-answers-embassy-details")
         else
-          messages("cds.form.check-answers-company-details")
+          messages("cds.form.check-answers-organisation-details")
 
       val providedDetails = getProvidedDetails(
         isIndividual,

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/viewModels/DateOfEstablishmentViewModel.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/viewModels/DateOfEstablishmentViewModel.scala
@@ -29,9 +29,9 @@ object DateOfEstablishmentViewModel {
 
   def headerAndTitle(orgType: EtmpOrganisationType, isRestOfWorldJourney: Boolean): String =
     (orgType, isRestOfWorldJourney) match {
-      case (Partnership | LLP, _) => "cds.subscription.partnership.date-of-establishment.title-and-heading"
-      case (CorporateBody, false) => "cds.subscription.date-of-establishment.company.title-and-heading"
-      case (_, _)                 => "cds.subscription.date-of-establishment.title-and-heading"
+      case (Partnership, _)             => "cds.subscription.partnership.date-of-establishment.title-and-heading"
+      case (CorporateBody | LLP, false) => "cds.subscription.date-of-establishment.company.title-and-heading"
+      case (_, _)                       => "cds.subscription.date-of-establishment.title-and-heading"
     }
 
 }

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/viewModels/DisclosePersonalDetailsConsentViewModel.scala
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/viewModels/DisclosePersonalDetailsConsentViewModel.scala
@@ -28,9 +28,9 @@ case class DisclosePersonalDetailsConsentViewModel @Inject() (requestSessionData
   def textPara2()(implicit messages: Messages, request: Request[AnyContent]): String = {
     val org = requestSessionData.userSelectedOrganisationType.getOrElse(CdsOrganisationType.Individual)
     org match {
-      case CdsOrganisationType.Company =>
+      case CdsOrganisationType.Company | CdsOrganisationType.LimitedLiabilityPartnership =>
         messages("ecc.subscription.organisation-disclose-personal-details-consent.org.para2")
-      case CdsOrganisationType.Partnership | CdsOrganisationType.LimitedLiabilityPartnership =>
+      case CdsOrganisationType.Partnership =>
         messages("ecc.subscription.organisation-disclose-personal-details-consent.partnership.para2")
       case CdsOrganisationType.CharityPublicBodyNotForProfit | CdsOrganisationType.ThirdCountryOrganisation =>
         messages("ecc.subscription.organisation-disclose-personal-details-consent.charity.para2")
@@ -41,9 +41,9 @@ case class DisclosePersonalDetailsConsentViewModel @Inject() (requestSessionData
   def questionLabel()(implicit messages: Messages, request: Request[AnyContent]): String = {
     val org = requestSessionData.userSelectedOrganisationType.getOrElse(CdsOrganisationType.Individual)
     org match {
-      case CdsOrganisationType.Company =>
+      case CdsOrganisationType.Company | CdsOrganisationType.LimitedLiabilityPartnership =>
         messages("ecc.subscription.organisation-disclose-personal-details-consent.org.question")
-      case CdsOrganisationType.Partnership | CdsOrganisationType.LimitedLiabilityPartnership =>
+      case CdsOrganisationType.Partnership =>
         messages("ecc.subscription.organisation-disclose-personal-details-consent.partnership.question")
       case CdsOrganisationType.CharityPublicBodyNotForProfit | CdsOrganisationType.ThirdCountryOrganisation =>
         messages("ecc.subscription.organisation-disclose-personal-details-consent.charity.question")

--- a/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/what_is_your_org_name.scala.html
+++ b/app/uk/gov/hmrc/eoricommoncomponent/frontend/views/what_is_your_org_name.scala.html
@@ -31,13 +31,13 @@
     @title = @{
         if(service.code==cdsCode) messages("cds.matching.organisation.name.title")
         else if(organisationType==PartnershipId) messages("cds.matching.partnership.name.title")
-        else messages("gagmr.matching.organisation.name.title")
+        else messages("cds.matching.organisation.name.title")
     }
 
     @formHeading = @{
         if(service.code==cdsCode) messages("cds.matching.organisation.name.heading")
         else if(organisationType==PartnershipId) messages("cds.matching.partnership.name.heading")
-        else messages("gagmr.matching.organisation.name.heading")
+        else messages("cds.matching.organisation.name.heading")
     }
 
     @layout_di(title, form = Some(matchOrgNameForm), service = service) {

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -31,7 +31,7 @@ cds.third-country-ids.third-country-uid-5.label=Third Country Unique Identificat
 cds.use-short-name.label=Does your company use a shortened or alternative name?
 cds.short-name.label=Short name
 cds.subscription.sic.individual.sic.label=SIC code
-cds.date-established.label=Date of establishment
+cds.date-established.label=Organisation establish date
 cds.date-established.partnership.label=Partnership establish date
 cds.date-of-birth.label=Date of birth
 cds.date-incorporated.label=Date of incorporation
@@ -688,11 +688,11 @@ cds.matching-error.business-details.company-name.invalid-chars=Company name cann
 
 cds.matching.organisation.name.title=What is the organisation’s name?
 cds.matching.partnership.name.title=What is your registered partnership name?
-gagmr.matching.organisation.name.title=What is the name of your organisation?
+cds.matching.organisation.name.title=What is your registered company name?
 cds.matching.organisation.name.label=Organisation name
 cds.matching.organisation.name.heading=What is the organisation’s name?
 cds.matching.partnership.name.heading=What is your registered partnership name?
-gagmr.matching.organisation.name.heading=What is the name of your organisation?
+cds.matching.organisation.name.heading=What is your registered company name?
 cds.matching.organisation-name.error.name=Enter your registered organisation name
 
 #Matching UTR UK
@@ -1193,7 +1193,7 @@ cds.form.partner-address=Partnership address
 cds.form.company-address=Company address
 cds.form.organisation-address=Organisation address
 cds.form.charity-public-body-address=Organisation’s address
-cds.form.business-details=Registered company address
+cds.form.business-details=Registered organisation address
 cds.form.embassy-address=Embassy’s address
 cds.form.shortened-name=Shortened name
 cds.form.sic-code=Standard Industrial Classification (SIC) code
@@ -1690,7 +1690,7 @@ cds.matching.name-id-organisation.registered-company.matching-page.utr= What is 
 cds.matching.name-id-organisation.partnership.utr=What is the partnership’s Self Assessment Unique Taxpayer Reference (UTR)?
 cds.matching.name-id-organisation.organisation.utr=What is the organisation’s Corporation Tax Unique Taxpayer Reference (UTR)?
 
-cds.subscription.date-of-establishment.company.title-and-heading=When was the company established?
+cds.subscription.date-of-establishment.company.title-and-heading=When was the organisation established?
 
 cds.subscription.address-details.postcode.row.label=Postal code
 
@@ -1931,13 +1931,13 @@ ecc.subscription.outcomes.guidance.xi.eori.href=<a href="https://www.tax.service
 
 ecc.subscription.organisation-disclose-personal-details-consent.title = ‘Check an EORI number’ service
 ecc.subscription.organisation-disclose-personal-details-consent.para1 =Anyone can use this service to <a href="https://www.tax.service.gov.uk/check-eori-number" class="govuk-link" target="_blank" rel="noopener noreferrer">check if an EORI number is valid (opens in new tab)</a>. Members of the public cannot use it to find out what your EORI number is.
-ecc.subscription.organisation-disclose-personal-details-consent.org.para2 = You can consent to show the company’s name and address alongside the EORI number. Doing so can help reduce errors and delays when moving goods.
+ecc.subscription.organisation-disclose-personal-details-consent.org.para2 = You can consent to show the organisation’s name and address alongside the EORI number. Doing so can help reduce errors and delays when moving goods.
 ecc.subscription.organisation-disclose-personal-details-consent.partnership.para2 = You can consent to show the partnership’s name and address alongside the EORI number. Doing so can help reduce errors and delays when moving goods.
 ecc.subscription.organisation-disclose-personal-details-consent.charity.para2 = You can consent to show the organisation’s name and address alongside the EORI number. Doing so can help reduce errors and delays when moving your goods.
 ecc.subscription.organisation-disclose-personal-details-consent.individual.para2 = You can consent to show your name and address alongside your EORI number. Doing so can help reduce errors and delays when moving your goods.
 ecc.subscription.organisation-disclose-personal-details-consent.withdraw-consent.para = You can withdraw your consent at any time by filling in a <a href="https://www.gov.uk/eori/get-help-or-report-a-change-of-circumstances" class="govuk-link" id="change-of-circumstances" target="_blank" rel="noopener noreferrer">change of circumstances form (opens in new tab)</a>.
 
-ecc.subscription.organisation-disclose-personal-details-consent.org.question = Do you consent to show the company’s name and address on the ‘Check an EORI number’ service?
+ecc.subscription.organisation-disclose-personal-details-consent.org.question = Do you consent to show the organisation’s name and address on the ‘Check an EORI number’ service?
 ecc.subscription.organisation-disclose-personal-details-consent.partnership.question = Do you consent to show the partnership’s name and address on the ‘Check an EORI number’ service?
 ecc.subscription.organisation-disclose-personal-details-consent.charity.question = Do you consent to show the organisation’s name and address on the ‘Check an EORI number’ service?
 ecc.subscription.organisation-disclose-personal-details-consent.individual.question = Do you consent to show your name and address on the ‘Check an EORI number’ service?

--- a/test/unit/controllers/CheckYourDetailsRegisterControllerSpec.scala
+++ b/test/unit/controllers/CheckYourDetailsRegisterControllerSpec.scala
@@ -109,7 +109,7 @@ class CheckYourDetailsRegisterControllerSpec
     when(mockSubscriptionDetails.personalDataDisclosureConsent).thenReturn(Some(true))
     when(mockSubscriptionDetails.contactDetails).thenReturn(Some(contactUkDetailsModelWithMandatoryValuesOnly))
     when(mockSessionCache.subscriptionDetails(any[Request[_]])).thenReturn(Future.successful(mockSubscriptionDetails))
-    when(mockRequestSession.isPartnershipOrLLP(any[Request[AnyContent]])).thenReturn(false)
+    when(mockRequestSession.isPartnership(any[Request[AnyContent]])).thenReturn(false)
     when(mockSubscriptionDetails.vatVerificationOption).thenReturn(Some(true))
     when(mockSubscriptionDetails.vatControlListResponse).thenReturn(vatControlListResponseDetails)
     when(mockVatControlListDetails.dateOfReg).thenReturn(Some("2017-01-01"))
@@ -214,7 +214,7 @@ class CheckYourDetailsRegisterControllerSpec
     "display the business name and address from the cache" in {
       showForm() { result =>
         val page = CdsPage(contentAsString(result))
-        page.getSummaryListValue(RegistrationReviewPage.SummaryListRowXPath, "Registered company address") shouldBe
+        page.getSummaryListValue(RegistrationReviewPage.SummaryListRowXPath, "Registered organisation address") shouldBe
           strim("""
                 |street
                 |city
@@ -285,7 +285,7 @@ class CheckYourDetailsRegisterControllerSpec
 
       showForm() { result =>
         val page = CdsPage(contentAsString(result))
-        page.getSummaryListValue(RegistrationReviewPage.SummaryListRowXPath, "Registered company address") shouldBe
+        page.getSummaryListValue(RegistrationReviewPage.SummaryListRowXPath, "Registered organisation address") shouldBe
           strim("""
                 |street
                 |city
@@ -340,7 +340,7 @@ class CheckYourDetailsRegisterControllerSpec
         ) shouldBe "9999"
         page.getSummaryListValue(
           RegistrationReviewPage.SummaryListRowXPath,
-          "Date of establishment"
+          "Organisation establish date"
         ) shouldBe "11 November 1900"
         page.summaryListElementPresent(RegistrationReviewPage.SummaryListRowXPath, "Date of birth") shouldBe false
       }
@@ -349,7 +349,7 @@ class CheckYourDetailsRegisterControllerSpec
     forAll(businessDetailsOrganisationTypes) { organisationType =>
       val labelText = organisationType match {
         case LimitedLiabilityPartnership =>
-          "Registered partnership name"
+          "Registered company name"
         case Partnership =>
           "Registered partnership name"
         case ThirdCountryOrganisation =>
@@ -473,7 +473,7 @@ class CheckYourDetailsRegisterControllerSpec
       val page: CdsPage = CdsPage(contentAsString(result))
       page.title() should startWith("Check your answers")
 
-      page.h2() should startWith("Company details VAT details Contact details Declaration Support links")
+      page.h2() should startWith("Organisation details VAT details Contact details Declaration Support links")
 
       page.getSummaryListValue(
         RegistrationReviewPage.SummaryListRowXPath,
@@ -491,9 +491,9 @@ class CheckYourDetailsRegisterControllerSpec
 
       page.summaryListElementPresent(
         RegistrationReviewPage.SummaryListRowXPath,
-        "Registered company address"
+        "Registered organisation address"
       ) shouldBe true
-      page.getSummaryListValue(RegistrationReviewPage.SummaryListRowXPath, "Registered company address") shouldBe
+      page.getSummaryListValue(RegistrationReviewPage.SummaryListRowXPath, "Registered organisation address") shouldBe
         strim("""
               |street
               |city
@@ -502,29 +502,32 @@ class CheckYourDetailsRegisterControllerSpec
           """)
       page.summaryListHrefPresent(
         RegistrationReviewPage.SummaryListRowXPath,
-        "Registered company address",
+        "Registered organisation address",
         "Change"
       ) shouldBe true
       page.getSummaryListHref(
         RegistrationReviewPage.SummaryListRowXPath,
-        "Registered company address",
+        "Registered organisation address",
         "Change"
       ) shouldBe "/customs-registration-services/atar/register/matching/confirm/review"
 
-      page.summaryListElementPresent(RegistrationReviewPage.SummaryListRowXPath, "Date of establishment") shouldBe true
+      page.summaryListElementPresent(
+        RegistrationReviewPage.SummaryListRowXPath,
+        "Organisation establish date"
+      ) shouldBe true
       page.getSummaryListValue(
         RegistrationReviewPage.SummaryListRowXPath,
-        "Date of establishment"
+        "Organisation establish date"
       ) shouldBe "23 July 1980"
       page.getSummaryListLink(
         RegistrationReviewPage.SummaryListRowXPath,
-        "Date of establishment",
+        "Organisation establish date",
         "Change"
       ) shouldBe SubscriptionExistingDetailsReviewPage
-        .changeAnswerText("Date of establishment")
+        .changeAnswerText("Organisation establish date")
       page.getSummaryListHref(
         RegistrationReviewPage.SummaryListRowXPath,
-        "Date of establishment",
+        "Organisation establish date",
         "Change"
       ) shouldBe "/customs-registration-services/atar/register/date-established/review"
 
@@ -612,7 +615,7 @@ class CheckYourDetailsRegisterControllerSpec
     }
   }
 
-  "display the review page check-your-details for LLP" ignore {
+  "display the review page check-your-details for LLP" in {
     when(mockSessionCache.registrationDetails(any[Request[_]]))
       .thenReturn(Future.successful(incorporatedRegistrationDetails.copy(customsId = Some(Utr("7280616009")))))
     val holder = detailsHolderWithAllFields.copy(
@@ -627,7 +630,7 @@ class CheckYourDetailsRegisterControllerSpec
       val page: CdsPage = CdsPage(contentAsString(result))
       page.title() should startWith("Check your answers")
 
-      page.h2() should startWith("Partnership details VAT details Contact details Declaration Support links")
+      page.h2() should startWith("Organisation details VAT details Contact details Declaration Support links")
 
       page.getSummaryListValue(
         RegistrationReviewPage.SummaryListRowXPath,
@@ -636,12 +639,9 @@ class CheckYourDetailsRegisterControllerSpec
 
       page.summaryListElementPresent(
         RegistrationReviewPage.SummaryListRowXPath,
-        "Registered partnership name"
+        "Registered company name"
       ) shouldBe true
-      page.getSummaryListValue(
-        RegistrationReviewPage.SummaryListRowXPath,
-        "Registered partnership name"
-      ) shouldBe "orgName"
+      page.getSummaryListValue(RegistrationReviewPage.SummaryListRowXPath, "Registered company name") shouldBe "orgName"
 
       page.summaryListElementPresent(
         RegistrationReviewPage.SummaryListRowXPath,
@@ -652,8 +652,11 @@ class CheckYourDetailsRegisterControllerSpec
         "Corporation Tax Unique Taxpayer Reference (UTR)"
       ) shouldBe "7280616009"
 
-      page.summaryListElementPresent(RegistrationReviewPage.SummaryListRowXPath, "Partnership address") shouldBe true
-      page.getSummaryListValue(RegistrationReviewPage.SummaryListRowXPath, "Partnership address") shouldBe
+      page.summaryListElementPresent(
+        RegistrationReviewPage.SummaryListRowXPath,
+        "Registered organisation address"
+      ) shouldBe true
+      page.getSummaryListValue(RegistrationReviewPage.SummaryListRowXPath, "Registered organisation address") shouldBe
         strim("""
               |street
               |city
@@ -662,24 +665,27 @@ class CheckYourDetailsRegisterControllerSpec
           """)
       page.summaryListHrefPresent(
         RegistrationReviewPage.SummaryListRowXPath,
-        "Partnership address",
+        "Registered organisation address",
         "Change"
       ) shouldBe true
 
-      page.summaryListElementPresent(RegistrationReviewPage.SummaryListRowXPath, "Date of establishment") shouldBe true
+      page.summaryListElementPresent(
+        RegistrationReviewPage.SummaryListRowXPath,
+        "Organisation establish date"
+      ) shouldBe true
       page.getSummaryListValue(
         RegistrationReviewPage.SummaryListRowXPath,
-        "Date of establishment"
+        "Organisation establish date"
       ) shouldBe "23 July 1980"
       page.getSummaryListLink(
         RegistrationReviewPage.SummaryListRowXPath,
-        "Date of establishment",
+        "Organisation establish date",
         "Change"
       ) shouldBe SubscriptionExistingDetailsReviewPage
-        .changeAnswerText("Date of establishment")
+        .changeAnswerText("Organisation establish date")
       page.getSummaryListHref(
         RegistrationReviewPage.SummaryListRowXPath,
-        "Date of establishment",
+        "Organisation establish date",
         "Change"
       ) shouldBe "/customs-registration-services/atar/register/date-established/review"
 
@@ -753,7 +759,7 @@ class CheckYourDetailsRegisterControllerSpec
       page.getSummaryListValue(
         RegistrationReviewPage.SummaryListRowXPath,
         "Show name and address on the 'Check an EORI number' service"
-      ) shouldBe "Yes I want my partnership name and address on the EORI checker"
+      ) shouldBe "Yes"
       page.getSummaryListHref(
         RegistrationReviewPage.SummaryListRowXPath,
         "Show name and address on the 'Check an EORI number' service",
@@ -801,7 +807,7 @@ class CheckYourDetailsRegisterControllerSpec
 
       page.summaryListHrefPresent(
         RegistrationReviewPage.SummaryListRowXPath,
-        "Registered company address",
+        "Registered organisation address",
         "Change"
       ) shouldBe true
     }
@@ -902,7 +908,7 @@ class CheckYourDetailsRegisterControllerSpec
     if (
       userSelectedOrgType.id == CdsOrganisationType.PartnershipId || userSelectedOrgType.id == CdsOrganisationType.LimitedLiabilityPartnershipId
     )
-      when(mockRequestSession.isPartnershipOrLLP(any[Request[AnyContent]])).thenReturn(true)
+      when(mockRequestSession.isPartnership(any[Request[AnyContent]])).thenReturn(true)
 
     when(mockSubscriptionFlow.isIndividualFlow).thenReturn(isIndividualSubscriptionFlow)
 

--- a/test/unit/controllers/ContactAddressControllerSpec.scala
+++ b/test/unit/controllers/ContactAddressControllerSpec.scala
@@ -25,6 +25,7 @@ import play.api.mvc.{AnyContent, Request, Result}
 import play.api.test.Helpers._
 import uk.gov.hmrc.eoricommoncomponent.frontend.controllers.{ContactAddressController, SubscriptionFlowManager}
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.CdsOrganisationType
+import uk.gov.hmrc.eoricommoncomponent.frontend.domain.registration.UserLocation
 import uk.gov.hmrc.eoricommoncomponent.frontend.domain.subscription.{
   SubscriptionDetails,
   SubscriptionFlowInfo,
@@ -63,6 +64,7 @@ class ContactAddressControllerSpec
     mockSubscriptionBusinessService,
     mockCdsFrontendDataCache,
     mockSubscriptionFlow,
+    mockRequestSessionData,
     mcc,
     viewContactAddress
   )(global)
@@ -192,13 +194,14 @@ class ContactAddressControllerSpec
       when(mockSubscriptionDetailsService.cachedOrganisationType(any())).thenReturn(
         Future.successful(Some(CdsOrganisationType.Company))
       )
+      when(mockRequestSessionData.selectedUserLocation(any())).thenReturn(Some(UserLocation.Uk))
       submitFormInCreateMode(validRequest) { result =>
         status(result) shouldBe SEE_OTHER
         header(
           LOCATION,
           result
-        ).value shouldBe uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes.DisclosePersonalDetailsConsentController
-          .createForm(atarService)
+        ).value shouldBe uk.gov.hmrc.eoricommoncomponent.frontend.controllers.routes.DetermineReviewPageController
+          .determineRoute(atarService)
           .url
 
       }
@@ -211,6 +214,7 @@ class ContactAddressControllerSpec
       when(mockSubscriptionDetailsService.cachedOrganisationType(any())).thenReturn(
         Future.successful(Some(CdsOrganisationType.Company))
       )
+      when(mockRequestSessionData.selectedUserLocation(any())).thenReturn(Some(UserLocation.Uk))
       submitFormInCreateMode(validRequestNo) { result =>
         status(result) shouldBe SEE_OTHER
         header(
@@ -266,6 +270,7 @@ class ContactAddressControllerSpec
         when(mockSubscriptionDetailsService.cachedOrganisationType(any())).thenReturn(
           Future.successful(Some(CdsOrganisationType.Embassy))
         )
+        when(mockRequestSessionData.selectedUserLocation(any())).thenReturn(Some(UserLocation.Uk))
         submitFormInCreateMode(validRequestNo) { result =>
           status(result) shouldBe SEE_OTHER
           header(

--- a/test/unit/controllers/DateOfEstablishmentControllerSpec.scala
+++ b/test/unit/controllers/DateOfEstablishmentControllerSpec.scala
@@ -171,14 +171,14 @@ class DateOfEstablishmentControllerSpec
       }
     }
 
-    "use partnership in title and heading for Limited Liability Partnership Org Type" in {
+    "use organisation in title and heading for Limited Liability Partnership Org Type" in {
       when(mockOrgTypeLookup.etmpOrgType(any[Request[AnyContent]])).thenReturn(Future.successful(LLP))
       showCreateForm(cachedDate = Some(DateOfEstablishment)) { result =>
         val page = CdsPage(contentAsString(result))
-        page.title() should startWith("When was the partnership established?")
+        page.title() should startWith("When was the organisation established?")
         page.getElementsText(
           SubscriptionDateOfEstablishmentPage.dateOfEstablishmentHeadingXPath
-        ) shouldBe "When was the partnership established?"
+        ) shouldBe "When was the organisation established?"
       }
     }
 
@@ -194,14 +194,14 @@ class DateOfEstablishmentControllerSpec
       }
     }
 
-    "use business in Date of Establishment text and organisation in title and heading for Company Org Type" in {
+    "use organisation in Date of Establishment text and in title and heading for Company Org Type" in {
       when(mockOrgTypeLookup.etmpOrgType(any[Request[AnyContent]])).thenReturn(Future.successful(CorporateBody))
       showCreateForm(cachedDate = Some(DateOfEstablishment)) { result =>
         val page = CdsPage(contentAsString(result))
-        page.title() should startWith("When was the company established?")
+        page.title() should startWith("When was the organisation established?")
         page.getElementsText(
           SubscriptionDateOfEstablishmentPage.dateOfEstablishmentHeadingXPath
-        ) shouldBe "When was the company established?"
+        ) shouldBe "When was the organisation established?"
       }
     }
   }

--- a/test/unit/controllers/DisclosePersonalDetailsConsentControllerSpec.scala
+++ b/test/unit/controllers/DisclosePersonalDetailsConsentControllerSpec.scala
@@ -421,7 +421,7 @@ class DisclosePersonalDetailsConsentControllerSpec
     )
     when(mockRequestSessionData.isRegistrationUKJourney(any())).thenReturn(isUkJourney)
     when(mockRequestSessionData.isIndividualOrSoleTrader(any())).thenReturn(isIndividual)
-    when(mockRequestSessionData.isPartnershipOrLLP(any())).thenReturn(isPartnership)
+    when(mockRequestSessionData.isPartnership(any())).thenReturn(isPartnership)
     when(mockRequestSessionData.isCharity(any())).thenReturn(isCharity)
 
     val orgType =
@@ -450,7 +450,7 @@ class DisclosePersonalDetailsConsentControllerSpec
       .thenReturn(Future.successful(previouslyAnswered))
     when(mockRequestSessionData.isRegistrationUKJourney(any())).thenReturn(isUkJourney)
     when(mockRequestSessionData.isIndividualOrSoleTrader(any())).thenReturn(isIndividual)
-    when(mockRequestSessionData.isPartnershipOrLLP(any())).thenReturn(isPartnership)
+    when(mockRequestSessionData.isPartnership(any())).thenReturn(isPartnership)
     when(mockRequestSessionData.isCharity(any())).thenReturn(isCharity)
 
     when(mockSubscriptionFlowManager.currentSubscriptionFlow(any[Request[AnyContent]], any[HeaderCarrier])).thenReturn(

--- a/test/unit/controllers/NameDobControllerSpec.scala
+++ b/test/unit/controllers/NameDobControllerSpec.scala
@@ -226,7 +226,17 @@ class NameDobControllerSpec extends ControllerSpec with BeforeAndAfterEach with 
       }
     }
 
-    "redirect to the confirm page when successful" in {
+    "redirect to the confirm page when successful for UK" in {
+      submitForm(ValidRequest, defaultOrganisationType) { result =>
+        status(result) shouldBe SEE_OTHER
+        header("Location", result).value should endWith(
+          "/customs-registration-services/atar/register/matching/chooseid"
+        )
+      }
+    }
+
+    "redirect to the confirm page when successful for Isle Of Man" in {
+      when(mockRequestSessionData.selectedUserLocation(any())).thenReturn(Some(UserLocation.Iom))
       submitForm(ValidRequest, defaultOrganisationType) { result =>
         status(result) shouldBe SEE_OTHER
         header("Location", result).value should endWith(
@@ -234,6 +244,7 @@ class NameDobControllerSpec extends ControllerSpec with BeforeAndAfterEach with 
         )
       }
     }
+
   }
 
   def showForm(userId: String = defaultUserId)(test: Future[Result] => Any): Unit = {

--- a/test/unit/controllers/WhatIsYourOrgNameControllerSpec.scala
+++ b/test/unit/controllers/WhatIsYourOrgNameControllerSpec.scala
@@ -134,7 +134,7 @@ class WhatIsYourOrgNameControllerSpec extends ControllerSpec with BeforeAndAfter
         showForm(reviewMode) { result =>
           status(result) shouldBe OK
           val page = CdsPage(contentAsString(result))
-          page.getElementsText(labelForNameOuter) shouldBe "What is the name of your organisation?"
+          page.getElementsText(labelForNameOuter) shouldBe "What is your registered company name?"
         }
       }
     }

--- a/test/unit/viewModels/CheckYourDetailsRegisterViewModelSpec.scala
+++ b/test/unit/viewModels/CheckYourDetailsRegisterViewModelSpec.scala
@@ -69,7 +69,7 @@ class CheckYourDetailsRegisterViewModelSpec extends UnitSpec with ControllerSpec
     }
     "return correct messages for SoleTrader is false" in organisationToTest.foreach { test =>
       val result = constructorInstance.getDateOfEstablishmentLabel(test)
-      result shouldBe "Date of establishment"
+      result shouldBe "Organisation establish date"
     }
   }
   "orgNameLabel" should {

--- a/test/unit/viewModels/DisclosePersonalDetailsConsentViewModelSpec.scala
+++ b/test/unit/viewModels/DisclosePersonalDetailsConsentViewModelSpec.scala
@@ -47,8 +47,8 @@ class DisclosePersonalDetailsConsentViewModelSpec extends UnitSpec with Controll
     ),
     (
       CdsOrganisationType.LimitedLiabilityPartnership,
-      messages("ecc.subscription.organisation-disclose-personal-details-consent.partnership.question"),
-      messages("ecc.subscription.organisation-disclose-personal-details-consent.partnership.para2")
+      messages("ecc.subscription.organisation-disclose-personal-details-consent.org.question"),
+      messages("ecc.subscription.organisation-disclose-personal-details-consent.org.para2")
     ),
     (
       CdsOrganisationType.CharityPublicBodyNotForProfit,

--- a/test/unit/views/DateOfEstablishmentSpec.scala
+++ b/test/unit/views/DateOfEstablishmentSpec.scala
@@ -39,13 +39,13 @@ class DateOfEstablishmentSpec extends ViewSpec with MockitoSugar {
 
   "On a UK journey the 'When was the organisation established?' page" should {
     "display correct title" in {
-      doc.title() must startWith("When was the company established?")
+      doc.title() must startWith("When was the organisation established?")
     }
     "have the correct h1 text" in {
-      doc.body.getElementsByTag("h1").text() mustBe "When was the company established?"
+      doc.body.getElementsByTag("h1").text() mustBe "When was the organisation established?"
     }
     "have the correct h2 text" in {
-      doc.body.getElementsByTag("h2").text() startsWith "When was the company established?"
+      doc.body.getElementsByTag("h2").text() startsWith "When was the organisation established?"
     }
     "have the correct class on the legend" in {
       doc.body.getElementsByTag("legend").hasClass("govuk-fieldset__legend") mustBe true
@@ -74,10 +74,10 @@ class DateOfEstablishmentSpec extends ViewSpec with MockitoSugar {
 
   "On an LLP org type journey Date Established page" should {
     "display correct title" in {
-      docLlp.title must startWith("When was the partnership established?")
+      docLlp.title must startWith("When was the organisation established?")
     }
     "have the correct legend text" in {
-      docLlp.body.getElementsByTag("legend").text() mustBe "When was the partnership established?"
+      docLlp.body.getElementsByTag("legend").text() mustBe "When was the organisation established?"
     }
     "have the correct class on the legend" in {
       docLlp.body.getElementsByTag("legend").hasClass("govuk-fieldset__legend") mustBe true

--- a/test/unit/views/MatchOrganisationNameSpec.scala
+++ b/test/unit/views/MatchOrganisationNameSpec.scala
@@ -42,10 +42,10 @@ class MatchOrganisationNameSpec extends ViewSpec {
       doc.title() must startWith(doc.body().getElementsByTag("h1").text())
     }
     "display correct heading" in {
-      doc.body().getElementsByTag("h1").text() mustBe "What is the name of your organisation?"
+      doc.body().getElementsByTag("h1").text() mustBe "What is your registered company name?"
     }
     "have the correct h1 text" in {
-      doc.body().getElementsByTag("h1").text() mustBe "What is the name of your organisation?"
+      doc.body().getElementsByTag("h1").text() mustBe "What is your registered company name?"
     }
     "have an input of type 'text' for organisation name" in {
       doc.body().getElementById("name").attr("type") mustBe "text"


### PR DESCRIPTION

*ISLE OF MAN COMPANY, LIMITED LIABILITY PARTNERSHIP*


*THE UK JOURNEY HAS BEEN FIXED IN THIS COMMIT, PREVIOUSLY IT WAS FOLLOWING iom BUT IT IS BACK*

LLP & Partnership have now diverged. LLP content is now the same as the content for Company.

ContactAddressController
 - Now redirects to the WhatIsYourContactAddressController for Company & LLP

OrganisationTypeController
 - Now redirects to the OrgNameController for Company & LLP

VatRegisteredUkController
 - isPartnershipOrLLP changed to isPartnership, the content is different for both

WhatIsYourOrgNameController
 - Now redirects to WhatIsYourOrganisationsAddressController for Company & LLP

WhatIsYourOrganisationsAddressController
 - redirectFlowLocation now handles IOM location for Company & LLP

SubscriptionFlow
 - CREATED NEW companyLlpFlowIomConfig
 - CREATED NEW CompanyLlpFlowIom that maps to that config

RequestSessionData
 - isPartnershipOrLLP has now been replaced with the existing isPartnership.
 - As stated at the top the content has diverged for LLP which now has the same content as Company

CheckYourDetailsRegisterViewModel
 - content changes for LLP & Company

DateOfEstablishmentViewModel
 - headerAndTitle function now accounts for Company & LLP header & title

DisclosePersonalDetailsConsentViewModel
 - paragraph 2 content update for Company & LLP
 - question label content update for Company & LLP

what_is_your_org_name.scala.html
 - gagmr renamed to cds

messages.en
 - label updates & header/title updates.